### PR TITLE
Staking contract with lock periods

### DIFF
--- a/contracts/staking.sol
+++ b/contracts/staking.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+contract Staking is ReentrancyGuard, Ownable {
+    
+    // The token being staked (TruthBountyToken)
+    IERC20 public stakingToken;
+
+    // Duration in seconds that tokens must be locked after staking
+    uint256 public lockDuration;
+
+    struct StakeInfo {
+        uint256 amount;      // Total amount currently staked
+        uint256 unlockTime;  // Timestamp when the stake allows withdrawal
+    }
+
+    // Mapping of user address to their stake details
+    mapping(address => StakeInfo) public stakes;
+
+    // Events for frontend indexing
+    event Staked(address indexed user, uint256 amount, uint256 totalStaked, uint256 unlockTime);
+    event Unstaked(address indexed user, uint256 amount, uint256 remainingStake);
+    event LockDurationUpdated(uint256 newDuration);
+
+    /**
+     * @param _stakingToken Address of the TruthBountyToken
+     * @param _initialLockDuration Initial lock time in seconds (e.g., 86400 for 1 day)
+     */
+    constructor(address _stakingToken, uint256 _initialLockDuration) Ownable(msg.sender) {
+        require(_stakingToken != address(0), "Invalid token address");
+        stakingToken = IERC20(_stakingToken);
+        lockDuration = _initialLockDuration;
+    }
+
+    /**
+     * @dev Stake tokens into the contract. 
+     * Resets the unlock timer for the ENTIRE balance to prevent manipulation.
+     * @param amount The amount of tokens to stake.
+     */
+    function stake(uint256 amount) external nonReentrant {
+        require(amount > 0, "Cannot stake 0");
+
+        // Transfer tokens from user to contract (requires approve())
+        stakingToken.transferFrom(msg.sender, address(this), amount);
+
+        StakeInfo storage info = stakes[msg.sender];
+        
+        // Update balance
+        info.amount += amount;
+        
+        // Reset lock period based on current time + duration
+        info.unlockTime = block.timestamp + lockDuration;
+
+        emit Staked(msg.sender, amount, info.amount, info.unlockTime);
+    }
+
+    /**
+     * @dev Withdraw staked tokens. Can only be called after lock period expires.
+     * @param amount The amount to withdraw.
+     */
+    function unstake(uint256 amount) external nonReentrant {
+        StakeInfo storage info = stakes[msg.sender];
+        
+        require(info.amount >= amount, "Insufficient staked balance");
+        require(block.timestamp >= info.unlockTime, "Stake is still locked");
+        require(amount > 0, "Cannot unstake 0");
+
+        // Update balance
+        info.amount -= amount;
+
+        // Transfer tokens back to user
+        stakingToken.transfer(msg.sender, amount);
+
+        emit Unstaked(msg.sender, amount, info.amount);
+    }
+
+    /**
+     * @dev Returns the full stake info for a user.
+     */
+    function getStakeInfo(address user) external view returns (uint256 amount, uint256 unlockTime, uint256 timeRemaining) {
+        StakeInfo memory info = stakes[user];
+        
+        uint256 remaining = 0;
+        if (block.timestamp < info.unlockTime) {
+            remaining = info.unlockTime - block.timestamp;
+        }
+
+        return (info.amount, info.unlockTime, remaining);
+    }
+
+    /**
+     * @dev Admin function to update the lock duration for FUTURE stakes.
+     */
+    function setLockDuration(uint256 _duration) external onlyOwner {
+        lockDuration = _duration;
+        emit LockDurationUpdated(_duration);
+    }
+}


### PR DESCRIPTION
# Implement Staking Contract with Lock Periods

**Closes #2**

## 📚 Overview
This PR implements the core staking mechanics for the TruthBounty ecosystem. It introduces a dedicated `Staking.sol` contract that allows users to stake **$BOUNTY** tokens and enforces a time-based lock period to prevent short-term manipulation.

## 🛠 Changes Made

### New Contract: `Staking.sol`
- **Staking Logic:** Users can deposit tokens via `stake(amount)`.
- **Lock Enforcement:** Implemented a `lockDuration` state variable.
  - *Note:* Staking additional tokens resets the unlock timer for the *entire* user balance to prevent "fast in/out" gaming.
- **Withdrawal:** `unstake(amount)` is restricted until `block.timestamp >= unlockTime`.
- **Security:** Added `ReentrancyGuard` to all transfer functions.
- **View Functions:** Added `getStakeInfo(user)` to return staked amount and remaining lock time for frontend integration.


## 🧪 Technical Implementation Details

| Feature | Implementation |
| :--- | :--- |
| **Lock Mechanism** | `unlockTime = block.timestamp + lockDuration` |
| **Access Control** | OpenZeppelin `Ownable` (Staking Contract Only) |
| **Safety** | OpenZeppelin `ReentrancyGuard` |
| **Events** | `Staked`, `Unstaked`, `LockDurationUpdated` |

## ✅ Acceptance Criteria Checklist
- [x] Users can stake tokens (`stake`).
- [x] Lock period is strictly enforced on `unstake`.
- [x] Staking additional amounts resets the lock timer.
- [x] Stake balances and unlock times are queryable.
- [x] Owner can update the lock duration for future stakes.

