### PR TITLE
feat: add Optimism Sepolia and Mainnet configs, env docs, and gas/RPC…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+###########################################
+# Optimism Sepolia & Mainnet Deployment   #
+###########################################
+
+# Private key for deployer (never commit real key)
+PRIVATE_KEY=your_private_key_here
+
+# Optimism Sepolia
+OPTIMISM_SEPOLIA_RPC_URL=https://sepolia.optimism.io
+OPTIMISM_SEPOLIA_GAS_PRICE=10000000
+
+# Optimism Mainnet
+OPTIMISM_MAINNET_RPC_URL=https://mainnet.optimism.io
+OPTIMISM_MAINNET_GAS_PRICE=10000000
+
+# Etherscan API Key (for contract verification)
+OPTIMISM_ETHERSCAN_API_KEY=your_optimism_etherscan_api_key

--- a/README.md
+++ b/README.md
@@ -82,6 +82,27 @@ TruthBounty treats smart contracts as **portable logic**, not ecosystem lock-in.
 
 ## 🛠️ Development Setup
 
+## 🛠️ Development Setup
+
+### Environment Variables
+
+Copy `.env.example` to `.env` and fill in the required values:
+
+```
+PRIVATE_KEY=your_private_key_here
+OPTIMISM_SEPOLIA_RPC_URL=https://sepolia.optimism.io
+OPTIMISM_SEPOLIA_GAS_PRICE=10000000
+OPTIMISM_MAINNET_RPC_URL=https://mainnet.optimism.io
+OPTIMISM_MAINNET_GAS_PRICE=10000000
+OPTIMISM_ETHERSCAN_API_KEY=your_optimism_etherscan_api_key
+```
+
+**Notes:**
+- Never commit your real private key.
+- Gas price can be omitted for auto, or set for custom deployments.
+- Use the correct RPC endpoints for your provider (Infura, Alchemy, etc).
+
+
 ### Prerequisites
 
 - Node.js v18+

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -7,14 +7,20 @@ dotenv.config();
 const config: HardhatUserConfig = {
   solidity: "0.8.28",
   networks: {
-    optimism: {
-      url: process.env.OPTIMISM_RPC_URL || "https://mainnet.optimism.io",
+    optimismSepolia: {
+      url: process.env.OPTIMISM_SEPOLIA_RPC_URL || "https://sepolia.optimism.io",
       accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [],
+      chainId: 11155420,
+      gas: "auto",
+      gasPrice: process.env.OPTIMISM_SEPOLIA_GAS_PRICE ? parseInt(process.env.OPTIMISM_SEPOLIA_GAS_PRICE) : undefined,
     },
-    optimism_sepolia: {  // Testnet
-      url: "https://sepolia.optimism.io",
+    optimismMainnet: {
+      url: process.env.OPTIMISM_MAINNET_RPC_URL || "https://mainnet.optimism.io",
       accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [],
-    }
+      chainId: 10,
+      gas: "auto",
+      gasPrice: process.env.OPTIMISM_MAINNET_GAS_PRICE ? parseInt(process.env.OPTIMISM_MAINNET_GAS_PRICE) : undefined,
+    },
   },
   etherscan: {
     apiKey: {


### PR DESCRIPTION
Closes #35 

# Add Optimism Sepolia → Mainnet Config

## Overview
Prepare deployment configurations for both testnet and mainnet environments to support contract deployments on Optimism.

## Objectives
- Network configs  
- Environment variables  
- Gas settings  
- RPC configuration  

## Scope
Hardhat configuration updates:
- `optimismSepolia` network  
- `optimismMainnet` network  

## Acceptance Criteria
- [x] Deployments succeed on Sepolia  
- [x] Mainnet config prepared  
- [x] Environment variables documented  

## Labels
- devops  
- blockchain  
- infrastructure