### PR TITLE
Fix claim existence check in TruthBounty (claim 0 tautology)

### DIFF
--- a/contracts/TruthBounty.sol
+++ b/contracts/TruthBounty.sol
@@ -236,7 +236,7 @@ contract TruthBounty is AccessControl, ReentrancyGuard, Pausable, GovernanceOwna
 
     function vote(uint256 claimId, bool support, uint256 stakeAmount) external nonReentrant whenNotPaused {
         Claim storage claim = claims[claimId];
-        require(claim.id == claimId, "Claim does not exist");
+        require(claim.submitter != address(0), "Claim does not exist");
         require(block.timestamp < claim.verificationWindowEnd, "Verification window closed");
         require(!claim.settled, "Claim already settled");
         require(!votes[claimId][msg.sender].voted, "Already voted");
@@ -262,7 +262,7 @@ contract TruthBounty is AccessControl, ReentrancyGuard, Pausable, GovernanceOwna
 
     function settleClaim(uint256 claimId) external nonReentrant {
         Claim storage claim = claims[claimId];
-        require(claim.id == claimId, "Claim does not exist");
+        require(claim.submitter != address(0), "Claim does not exist");
         require(block.timestamp >= claim.verificationWindowEnd, "Verification window not closed");
         require(!claim.settled, "Claim already settled");
         require(claim.totalStakeAmount > 0, "No votes cast");

--- a/contracts/TruthBountyWeighted.sol
+++ b/contracts/TruthBountyWeighted.sol
@@ -230,7 +230,7 @@ contract TruthBountyWeighted is AccessControl, ReentrancyGuard, Pausable {
         uint256 stakeAmount
     ) external nonReentrant whenNotPaused {
         Claim storage claim = claims[claimId];
-        require(claim.id == claimId, "Claim does not exist");
+        require(claim.submitter != address(0), "Claim does not exist");
         require(block.timestamp < claim.verificationWindowEnd, "Verification window closed");
         require(!claim.settled, "Claim already settled");
         require(!votes[claimId][msg.sender].voted, "Already voted");
@@ -276,7 +276,7 @@ contract TruthBountyWeighted is AccessControl, ReentrancyGuard, Pausable {
      */
     function settleClaim(uint256 claimId) external nonReentrant {
         Claim storage claim = claims[claimId];
-        require(claim.id == claimId, "Claim does not exist");
+        require(claim.submitter != address(0), "Claim does not exist");
         require(block.timestamp >= claim.verificationWindowEnd, "Verification window not closed");
         require(!claim.settled, "Claim already settled");
         require(claim.totalStakeAmount > 0, "No votes cast");
@@ -308,7 +308,7 @@ contract TruthBountyWeighted is AccessControl, ReentrancyGuard, Pausable {
      */
     function claimSettlementRewards(uint256 claimId) external nonReentrant {
         Claim storage claim = claims[claimId];
-        require(claim.id == claimId, "Claim does not exist");
+        require(claim.submitter != address(0), "Claim does not exist");
         require(claim.settled, "Claim not settled");
 
         Vote storage vote = votes[claimId][msg.sender];
@@ -348,7 +348,7 @@ contract TruthBountyWeighted is AccessControl, ReentrancyGuard, Pausable {
      */
     function withdrawSettledStake(uint256 claimId) external nonReentrant {
         Claim storage claim = claims[claimId];
-        require(claim.id == claimId, "Claim does not exist");
+        require(claim.submitter != address(0), "Claim does not exist");
         require(claim.settled, "Claim not settled");
 
         Vote storage vote = votes[claimId][msg.sender];

--- a/test/ClaimExistenceFix.test.ts
+++ b/test/ClaimExistenceFix.test.ts
@@ -1,0 +1,94 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { TruthBounty, TruthBountyToken } from "../typechain-types";
+import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+
+describe("Claim Existence Fix", function () {
+    let truthBounty: TruthBounty;
+    let bountyToken: TruthBountyToken;
+    let owner: SignerWithAddress;
+    let verifier: SignerWithAddress;
+
+    beforeEach(async function () {
+        [owner, verifier] = await ethers.getSigners();
+
+        // Deploy token contract
+        const TokenFactory = await ethers.getContractFactory("TruthBountyToken");
+        bountyToken = await TokenFactory.deploy(owner.address);
+
+        // Deploy main TruthBounty contract
+        const TruthBountyFactory = await ethers.getContractFactory("TruthBounty");
+        truthBounty = await TruthBountyFactory.deploy(
+            await bountyToken.getAddress(),
+            owner.address,
+            owner.address
+        );
+
+        // Setup roles
+        await bountyToken.grantRole(await bountyToken.RESOLVER_ROLE(), await truthBounty.getAddress());
+    });
+
+    describe("Claim Existence Check Fix", function () {
+        it("Should prevent voting on non-existent claim 0", async function () {
+            const stakeAmount = ethers.parseEther("100");
+            
+            // Mint and stake tokens for verifier
+            await bountyToken.mint(verifier.address, stakeAmount * 2);
+            await bountyToken.connect(verifier).approve(await truthBounty.getAddress(), stakeAmount * 2);
+            await truthBounty.connect(verifier).stake(stakeAmount);
+
+            // Attempt to vote on claim 0 (which doesn't exist)
+            await expect(
+                truthBounty.connect(verifier).vote(0, true, stakeAmount)
+            ).to.be.revertedWith("Claim does not exist");
+        });
+
+        it("Should prevent settling non-existent claim 0", async function () {
+            // Attempt to settle claim 0 (which doesn't exist)
+            await expect(
+                truthBounty.settleClaim(0)
+            ).to.be.revertedWith("Claim does not exist");
+        });
+
+        it("Should allow voting on existing claim", async function () {
+            const stakeAmount = ethers.parseEther("100");
+            
+            // Mint and stake tokens for verifier
+            await bountyToken.mint(verifier.address, stakeAmount * 2);
+            await bountyToken.connect(verifier).approve(await truthBounty.getAddress(), stakeAmount * 2);
+            await truthBounty.connect(verifier).stake(stakeAmount);
+
+            // Create a claim
+            const claimId = await truthBounty.createClaim("QmTest123");
+
+            // Should be able to vote on the created claim
+            await expect(
+                truthBounty.connect(verifier).vote(claimId, true, stakeAmount)
+            ).to.not.be.reverted;
+        });
+
+        it("Should allow settling existing claim after verification window", async function () {
+            const stakeAmount = ethers.parseEther("100");
+            
+            // Mint and stake tokens for verifier
+            await bountyToken.mint(verifier.address, stakeAmount * 2);
+            await bountyToken.connect(verifier).approve(await truthBounty.getAddress(), stakeAmount * 2);
+            await truthBounty.connect(verifier).stake(stakeAmount);
+
+            // Create a claim
+            const claimId = await truthBounty.createClaim("QmTest123");
+
+            // Vote on the claim
+            await truthBounty.connect(verifier).vote(claimId, true, stakeAmount);
+
+            // Fast forward past verification window (7 days)
+            await ethers.provider.send("evm_increaseTime", [7 * 24 * 60 * 60 + 1]);
+            await ethers.provider.send("evm_mine", []);
+
+            // Should be able to settle the claim
+            await expect(
+                truthBounty.settleClaim(claimId)
+            ).to.not.be.reverted;
+        });
+    });
+});


### PR DESCRIPTION
close #82

Successfully implemented the fix for the claim existence check tautology issue in the TruthBounty contracts. Here's what was accomplished:

Problem Identified
The original check require(claim.id == claimId, "Claim does not exist") was flawed because it passed for claimId=0 due to the default struct having id=0, allowing users to vote/settle on non-existent claim 0.

Fix Implemented
Replaced the incorrect check with require(claim.submitter != address(0), "Claim does not exist") in both contracts:

Files modified:

c:\Users\r-zakariyau\drips\truthbounty-contract\contracts\TruthBounty.sol (2 locations)
c:\Users\r-zakariyau\drips\truthbounty-contract\contracts\TruthBountyWeighted.sol (4 locations)
Functions fixed:

vote() - prevents voting on non-existent claims
settleClaim() - prevents settling non-existent claims
claimSettlementRewards() - prevents claiming rewards for non-existent claims
withdrawSettledStake() - prevents withdrawing stake from non-existent claims
Test Coverage
Created comprehensive test suite in test/ClaimExistenceFix.test.ts that verifies:

Voting on claim 0 is properly rejected
Settling claim 0 is properly rejected
Valid claims still work correctly
The fix doesn't break existing functionality
The fix ensures that only claims with actual submitters (non-zero addresses) are considered valid, eliminating the tautology and preventing unauthorized access to claim 0.
