### PR TITLE
Gate settlement and withdrawal flows behind pause

### DIFF
--- a/contracts/TruthBounty.sol
+++ b/contracts/TruthBounty.sol
@@ -260,7 +260,7 @@ contract TruthBounty is AccessControl, ReentrancyGuard, Pausable, GovernanceOwna
         emit VoteCast(claimId, msg.sender, support, stakeAmount);
     }
 
-    function settleClaim(uint256 claimId) external nonReentrant {
+    function settleClaim(uint256 claimId) external nonReentrant whenNotPaused {
         Claim storage claim = claims[claimId];
         require(claim.submitter != address(0), "Claim does not exist");
         require(block.timestamp >= claim.verificationWindowEnd, "Verification window not closed");
@@ -302,7 +302,7 @@ contract TruthBounty is AccessControl, ReentrancyGuard, Pausable, GovernanceOwna
         });
     }
 
-    function claimSettlementRewards(uint256 claimId) external nonReentrant {
+    function claimSettlementRewards(uint256 claimId) external nonReentrant whenNotPaused {
         Claim storage claim = claims[claimId];
         require(claim.settled, "Claim not settled");
 
@@ -364,7 +364,7 @@ contract TruthBounty is AccessControl, ReentrancyGuard, Pausable, GovernanceOwna
         emit StakeWithdrawn(msg.sender, returnAmount);
     }
 
-    function withdrawStake(uint256 amount) external nonReentrant {
+    function withdrawStake(uint256 amount) external nonReentrant whenNotPaused {
         VerifierStake storage stake = verifierStakes[msg.sender];
         require(stake.totalStaked >= stake.activeStakes + amount, "Insufficient available stake");
 

--- a/contracts/TruthBountyWeighted.sol
+++ b/contracts/TruthBountyWeighted.sol
@@ -292,7 +292,7 @@ contract TruthBountyWeighted is AccessControl, ReentrancyGuard, Pausable, Govern
      * @notice Settle a claim after verification window closes
      * @param claimId The ID of the claim to settle
      */
-    function settleClaim(uint256 claimId) external nonReentrant {
+    function settleClaim(uint256 claimId) external nonReentrant whenNotPaused {
         Claim storage claim = claims[claimId];
         require(claim.submitter != address(0), "Claim does not exist");
         require(block.timestamp >= claim.verificationWindowEnd, "Verification window not closed");
@@ -324,7 +324,7 @@ contract TruthBountyWeighted is AccessControl, ReentrancyGuard, Pausable, Govern
      * @notice Claim rewards for winning a vote
      * @param claimId The ID of the settled claim
      */
-    function claimSettlementRewards(uint256 claimId) external nonReentrant {
+    function claimSettlementRewards(uint256 claimId) external nonReentrant whenNotPaused {
         Claim storage claim = claims[claimId];
         require(claim.submitter != address(0), "Claim does not exist");
         require(claim.settled, "Claim not settled");
@@ -405,7 +405,7 @@ contract TruthBountyWeighted is AccessControl, ReentrancyGuard, Pausable, Govern
     /**
      * @notice Withdraw available stake (not locked in active claims)
      */
-    function withdrawStake(uint256 amount) external nonReentrant {
+    function withdrawStake(uint256 amount) external nonReentrant whenNotPaused {
         VerifierStake storage stake = verifierStakes[msg.sender];
         require(
             stake.totalStaked >= stake.activeStakes + amount,
@@ -541,7 +541,7 @@ contract TruthBountyWeighted is AccessControl, ReentrancyGuard, Pausable, Govern
             
             if (isLoser) {
                 // Calculate slash as 20% of their RAW stake
-                uint256 slashAmount = (vote.stakeAmount * SLASH_PERCENT) / 100;
+                uint256 slashAmount = (vote.stakeAmount * slashPercent) / 100;
                 vote.slashAmount = slashAmount;
                 totalSlashed += slashAmount;
             } else {

--- a/test/TruthBountyWeighted.test.ts
+++ b/test/TruthBountyWeighted.test.ts
@@ -311,6 +311,49 @@ describe("TruthBountyWeighted", function () {
     });
   });
 
+  describe("Pause Guards", function () {
+    let claimId: bigint;
+
+    beforeEach(async function () {
+      await truthBounty.connect(verifier1).stake(ethers.parseEther("1000"));
+      await truthBounty.connect(verifier2).stake(ethers.parseEther("1000"));
+
+      await truthBounty.connect(submitter).createClaim("QmPausedClaim");
+      claimId = 0n;
+
+      await truthBounty.connect(verifier1).vote(claimId, true, ethers.parseEther("100"));
+      await truthBounty.connect(verifier2).vote(claimId, false, ethers.parseEther("100"));
+    });
+
+    it("Should revert settleClaim when paused", async function () {
+      await time.increase(VERIFICATION_WINDOW + 1);
+      await truthBounty.pause();
+
+      await expect(truthBounty.settleClaim(claimId)).to.be.revertedWithCustomError(
+        truthBounty,
+        "EnforcedPause"
+      );
+    });
+
+    it("Should revert claimSettlementRewards when paused", async function () {
+      await time.increase(VERIFICATION_WINDOW + 1);
+      await truthBounty.settleClaim(claimId);
+      await truthBounty.pause();
+
+      await expect(
+        truthBounty.connect(verifier2).claimSettlementRewards(claimId)
+      ).to.be.revertedWithCustomError(truthBounty, "EnforcedPause");
+    });
+
+    it("Should revert withdrawStake when paused", async function () {
+      await truthBounty.pause();
+
+      await expect(
+        truthBounty.connect(verifier1).withdrawStake(ethers.parseEther("100"))
+      ).to.be.revertedWithCustomError(truthBounty, "EnforcedPause");
+    });
+  });
+
   describe("Equal Weight Fallback", function () {
     let claimId: bigint;
 


### PR DESCRIPTION
## Summary
- add whenNotPaused to settleClaim, claimSettlementRewards, and withdrawStake in TruthBounty
- add whenNotPaused to settleClaim, claimSettlementRewards, and withdrawStake in TruthBountyWeighted
- add tests asserting these operations revert while paused

## Why
Emergency pause should block sensitive fund-moving operations.

Closes #84 