### PR TITLE
fix: distribute reward payout remainder

### DIFF
--- a/contracts/TruthBountyWeighted.sol
+++ b/contracts/TruthBountyWeighted.sol
@@ -96,6 +96,9 @@ contract TruthBountyWeighted is AccessControl, ReentrancyGuard, Pausable, Govern
         uint256 totalSlashed;
         uint256 winnerWeightedStake;   // Changed to weighted (NEW)
         uint256 loserWeightedStake;    // Changed to weighted (NEW)
+        uint256 winnerCount;           // Number of winning voters eligible for rewards
+        uint256 winnersClaimed;        // Number of winning voters that claimed rewards
+        uint256 rewardsClaimed;        // Total rewards already distributed
     }
 
     struct VerifierStake {
@@ -340,8 +343,16 @@ contract TruthBountyWeighted is AccessControl, ReentrancyGuard, Pausable, Govern
         bool isWinner = (vote.support == settlement.passed);
         require(isWinner, "Not a winner");
 
-        // Calculate proportional reward based on EFFECTIVE stake
+        // Calculate proportional reward based on EFFECTIVE stake. Integer division can
+        // leave a remainder, so assign any undistributed dust to the final winning
+        // claimant to ensure totalRewards is fully paid out.
         uint256 reward = (vote.effectiveStake * settlement.totalRewards) / settlement.winnerWeightedStake;
+
+        settlement.winnersClaimed += 1;
+        if (settlement.winnersClaimed == settlement.winnerCount) {
+            reward = settlement.totalRewards - settlement.rewardsClaimed;
+        }
+        settlement.rewardsClaimed += reward;
 
         // Mark as claimed
         vote.rewardClaimed = true;
@@ -518,8 +529,25 @@ contract TruthBountyWeighted is AccessControl, ReentrancyGuard, Pausable, Govern
             totalRewards: rewardAmount,
             totalSlashed: slashedAmount,
             winnerWeightedStake: winnerWeightedStake,
-            loserWeightedStake: loserWeightedStake
+            loserWeightedStake: loserWeightedStake,
+            winnerCount: _countWinners(claimId, passed),
+            winnersClaimed: 0,
+            rewardsClaimed: 0
         });
+    }
+
+    /**
+     * @notice Count voters on the winning side for remainder-safe reward distribution
+     */
+    function _countWinners(uint256 claimId, bool passed) internal view returns (uint256 count) {
+        address[] storage voters = claimVoters[claimId];
+
+        for (uint256 i = 0; i < voters.length; i++) {
+            Vote storage vote = votes[claimId][voters[i]];
+            if (vote.support == passed) {
+                count += 1;
+            }
+        }
     }
 
     /**

--- a/test/TruthBountyWeighted.test.ts
+++ b/test/TruthBountyWeighted.test.ts
@@ -309,6 +309,39 @@ describe("TruthBountyWeighted", function () {
       expect(reward1).to.be.closeTo(verifier1RewardShare, ethers.parseEther("0.01"));
       expect(reward2).to.be.closeTo(verifier2RewardShare, ethers.parseEther("0.01"));
     });
+
+    it("Should fully distribute reward remainder instead of leaving dust", async function () {
+      await truthBounty.setMinStakeAmount(1);
+      await truthBounty.setSlashPercent(100);
+      await truthBounty.setRewardPercent(100);
+
+      await mockOracle.setReputationScore(await verifier1.getAddress(), ethers.parseEther("1"));
+      await mockOracle.setReputationScore(await verifier2.getAddress(), ethers.parseEther("2"));
+      await mockOracle.setReputationScore(await verifier3.getAddress(), ethers.parseEther("0.1"));
+
+      await truthBounty.connect(verifier1).vote(claimId, true, 1);
+      await truthBounty.connect(verifier2).vote(claimId, true, 1);
+      await truthBounty.connect(verifier3).vote(claimId, false, 10);
+
+      await time.increase(VERIFICATION_WINDOW + 1);
+      await truthBounty.settleClaim(claimId);
+
+      const settlement = await truthBounty.settlementResults(claimId);
+      expect(settlement.totalRewards).to.equal(10);
+
+      const balanceBefore1 = await bountyToken.balanceOf(await verifier1.getAddress());
+      await truthBounty.connect(verifier1).claimSettlementRewards(claimId);
+      const balanceAfter1 = await bountyToken.balanceOf(await verifier1.getAddress());
+
+      const balanceBefore2 = await bountyToken.balanceOf(await verifier2.getAddress());
+      await truthBounty.connect(verifier2).claimSettlementRewards(claimId);
+      const balanceAfter2 = await bountyToken.balanceOf(await verifier2.getAddress());
+
+      const reward1 = balanceAfter1 - balanceBefore1 - 1n;
+      const reward2 = balanceAfter2 - balanceBefore2 - 1n;
+
+      expect(reward1 + reward2).to.equal(settlement.totalRewards);
+    });
   });
 
   describe("Pause Guards", function () {


### PR DESCRIPTION
## Summary
- Fixes reward payout dust caused by per-winner integer division in `TruthBountyWeighted.claimSettlementRewards()`.
- Tracks how many winning voters have claimed and how many reward tokens have already been distributed.
- Assigns the remaining undistributed reward amount to the final winning claimant so `settlement.totalRewards` is fully paid out.
- Adds a regression test covering a `totalRewards = 10`, winner weights `1:2` case where naive payouts leave `1` token of dust.

Closes #169

## Test plan
- Added regression test: `Should fully distribute reward remainder instead of leaving dust`.
- Attempted targeted test:

```bash
npm test -- --grep "fully distribute reward remainder"
```

- The targeted Hardhat run is currently blocked before test execution by existing repository compile issues unrelated to this patch:
  - `TruthBountyToken` inherits `UUPSUpgradeable` but lacks `_authorizeUpgrade(address)`.
  - `GovernanceController.onlyProposalExecutor()` conflicts with the inherited non-virtual modifier.
  - `GovernanceController` references `AccessControl.AccessDenied()`, which is not visible in the imported OpenZeppelin type.

- Verified the patched target contract compiles in isolation:

```bash
npx -p solc@0.8.28 solcjs --bin contracts/TruthBountyWeighted.sol --include-path node_modules --base-path . -o /tmp/truthbounty-solc-out
```

Result: exit code 0, warnings only.

## Notes
The fix preserves proportional distribution for all claimants except for the unavoidable integer-division remainder, which is paid to the final winning claimant instead of being retained as contract dust.