### PR TITLE
Validate bridged reputation payloads

### DIFF
--- a/contracts/ReputationReceiver.sol
+++ b/contracts/ReputationReceiver.sol
@@ -11,6 +11,7 @@ import "./IReputationOracle.sol";
  */
 contract ReputationReceiver is AccessControl {
     bytes32 public constant RECEIVER_ROLE = keccak256("RECEIVER_ROLE");
+    uint256 public constant MAX_PROOF_LENGTH = 64;
 
     IReputationOracle public reputationOracle;
 
@@ -35,11 +36,22 @@ contract ReputationReceiver is AccessControl {
     );
 
     // Errors
+    error InvalidAdmin();
+    error InvalidOracle();
+    error InvalidUser();
+    error InvalidSourceChainId();
+    error InvalidSnapshotRoot();
+    error InvalidTimestamp();
+    error InvalidProofIndex();
+    error ProofTooLong();
     error InvalidProof();
     error RootNotVerified();
     error ReputationAlreadyBridged();
 
     constructor(address admin, IReputationOracle _oracle) {
+        if (admin == address(0)) revert InvalidAdmin();
+        if (address(_oracle) == address(0)) revert InvalidOracle();
+
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
         _grantRole(RECEIVER_ROLE, admin);
         reputationOracle = _oracle;
@@ -56,6 +68,9 @@ contract ReputationReceiver is AccessControl {
         uint256 snapshotId,
         bytes32 root
     ) external onlyRole(RECEIVER_ROLE) {
+        if (sourceChainId == 0) revert InvalidSourceChainId();
+        if (root == bytes32(0)) revert InvalidSnapshotRoot();
+
         verifiedRoots[sourceChainId][snapshotId] = root;
         emit SnapshotRootVerified(sourceChainId, snapshotId, root);
     }
@@ -79,6 +94,12 @@ contract ReputationReceiver is AccessControl {
         bytes32[] calldata proof,
         uint256 proofIndex
     ) external onlyRole(RECEIVER_ROLE) {
+        if (user == address(0)) revert InvalidUser();
+        if (sourceChainId == 0) revert InvalidSourceChainId();
+        if (timestamp == 0) revert InvalidTimestamp();
+        if (proof.length > MAX_PROOF_LENGTH) revert ProofTooLong();
+        if (proofIndex >= (uint256(1) << proof.length)) revert InvalidProofIndex();
+
         bytes32 root = verifiedRoots[sourceChainId][snapshotId];
         if (root == bytes32(0)) revert RootNotVerified();
 

--- a/contracts/TruthBounty.sol
+++ b/contracts/TruthBounty.sol
@@ -107,6 +107,8 @@ contract TruthBountyToken is ERC20, AccessControl, Initializable, UUPSUpgradeabl
             reason
         );
     }
+
+    function _authorizeUpgrade(address newImplementation) internal override onlyRole(ADMIN_ROLE) {}
 }
 
 /**

--- a/contracts/governance/GovernanceController.sol
+++ b/contracts/governance/GovernanceController.sol
@@ -68,9 +68,9 @@ contract GovernanceController is GovernorAccessControl, ReentrancyGuard, Governa
 
     // ============ Modifiers ============
     
-    modifier onlyProposalExecutor() {
+    modifier onlyProposalExecutor() override {
         if (!hasRole(GovernorAccess.PROPOSAL_EXECUTOR_ROLE, msg.sender)) {
-            revert AccessControl.AccessDenied();
+            revert GovernorAccess.NotProposalExecutor(msg.sender);
         }
         _;
     }

--- a/contracts/governance/GovernorAccess.sol
+++ b/contracts/governance/GovernorAccess.sol
@@ -180,7 +180,7 @@ abstract contract GovernorAccessControl is AccessControl {
         _;
     }
     
-    modifier onlyProposalExecutor() {
+    modifier onlyProposalExecutor() virtual {
         if (!hasRole(GovernorAccess.PROPOSAL_EXECUTOR_ROLE, msg.sender) && 
             !hasRole(DEFAULT_ADMIN_ROLE, msg.sender)) {
             revert GovernorAccess.NotProposalExecutor(msg.sender);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@openzeppelin/contracts": "^5.4.0",
+        "@openzeppelin/contracts-upgradeable": "^5.6.1",
         "dotenv": "^16.4.7"
       },
       "devDependencies": {
@@ -1903,6 +1904,15 @@
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.6.1.tgz",
       "integrity": "sha512-Ly6SlsVJ3mj+b18W3R8gNufB7dTICT105fJhodGAGgyC2oqnBAhqSiNDJ8V8DLY05cCz81GLI0CU5vNYA1EC/w==",
       "license": "MIT"
+    },
+    "node_modules/@openzeppelin/contracts-upgradeable": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-5.6.1.tgz",
+      "integrity": "sha512-n4a/vfRs114lXyUdYg7pyY8LvFKWvCDF5lEcRRAVxap8g6ZEdLqm+9tmt2zTtRHcNMxTYp9y5t6KBof4tHp7Og==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@openzeppelin/contracts": "5.6.1"
+      }
     },
     "node_modules/@openzeppelin/defender-sdk-base-client": {
       "version": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "@openzeppelin/contracts": "^5.4.0",
+    "@openzeppelin/contracts-upgradeable": "^5.6.1",
     "dotenv": "^16.4.7"
   }
 }

--- a/test/ReputationReceiver.test.ts
+++ b/test/ReputationReceiver.test.ts
@@ -1,0 +1,172 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs";
+
+describe("ReputationReceiver", function () {
+  async function deployFixture() {
+    const [admin, receiver, user] = await ethers.getSigners();
+
+    const MockReputationOracle =
+      await ethers.getContractFactory("MockReputationOracle");
+    const oracle = await MockReputationOracle.deploy();
+    await oracle.waitForDeployment();
+
+    const ReputationReceiver =
+      await ethers.getContractFactory("ReputationReceiver");
+    const reputationReceiver = await ReputationReceiver.deploy(
+      admin.address,
+      await oracle.getAddress()
+    );
+    await reputationReceiver.waitForDeployment();
+
+    return { admin, receiver, user, oracle, reputationReceiver };
+  }
+
+  function leafFor(user: string, score: bigint, timestamp: bigint) {
+    return ethers.solidityPackedKeccak256(
+      ["address", "uint256", "uint256"],
+      [user, score, timestamp]
+    );
+  }
+
+  it("rejects invalid constructor addresses", async function () {
+    const [admin] = await ethers.getSigners();
+    const MockReputationOracle =
+      await ethers.getContractFactory("MockReputationOracle");
+    const oracle = await MockReputationOracle.deploy();
+    await oracle.waitForDeployment();
+
+    const ReputationReceiver =
+      await ethers.getContractFactory("ReputationReceiver");
+
+    await expect(
+      ReputationReceiver.deploy(ethers.ZeroAddress, await oracle.getAddress())
+    ).to.be.revertedWithCustomError(ReputationReceiver, "InvalidAdmin");
+
+    await expect(
+      ReputationReceiver.deploy(admin.address, ethers.ZeroAddress)
+    ).to.be.revertedWithCustomError(ReputationReceiver, "InvalidOracle");
+  });
+
+  it("rejects invalid snapshot roots", async function () {
+    const { reputationReceiver } = await deployFixture();
+
+    await expect(
+      reputationReceiver.verifySnapshotRoot(0, 1, ethers.keccak256("0x01"))
+    ).to.be.revertedWithCustomError(
+      reputationReceiver,
+      "InvalidSourceChainId"
+    );
+
+    await expect(
+      reputationReceiver.verifySnapshotRoot(1, 1, ethers.ZeroHash)
+    ).to.be.revertedWithCustomError(
+      reputationReceiver,
+      "InvalidSnapshotRoot"
+    );
+  });
+
+  it("rejects malformed bridged reputation payloads before proof verification", async function () {
+    const { reputationReceiver, user } = await deployFixture();
+    const score = 42n;
+    const timestamp = 1_700_000_000n;
+    const root = leafFor(user.address, score, timestamp);
+    await reputationReceiver.verifySnapshotRoot(1, 1, root);
+
+    await expect(
+      reputationReceiver.receiveBridgedReputation(
+        ethers.ZeroAddress,
+        1,
+        1,
+        score,
+        timestamp,
+        [],
+        0
+      )
+    ).to.be.revertedWithCustomError(reputationReceiver, "InvalidUser");
+
+    await expect(
+      reputationReceiver.receiveBridgedReputation(
+        user.address,
+        0,
+        1,
+        score,
+        timestamp,
+        [],
+        0
+      )
+    ).to.be.revertedWithCustomError(
+      reputationReceiver,
+      "InvalidSourceChainId"
+    );
+
+    await expect(
+      reputationReceiver.receiveBridgedReputation(
+        user.address,
+        1,
+        1,
+        score,
+        0,
+        [],
+        0
+      )
+    ).to.be.revertedWithCustomError(reputationReceiver, "InvalidTimestamp");
+
+    await expect(
+      reputationReceiver.receiveBridgedReputation(
+        user.address,
+        1,
+        1,
+        score,
+        timestamp,
+        [],
+        1
+      )
+    ).to.be.revertedWithCustomError(reputationReceiver, "InvalidProofIndex");
+  });
+
+  it("rejects oversized Merkle proofs", async function () {
+    const { reputationReceiver, user } = await deployFixture();
+    const oversizedProof = Array.from({ length: 65 }, (_, index) =>
+      ethers.keccak256(ethers.toUtf8Bytes(`proof-${index}`))
+    );
+
+    await expect(
+      reputationReceiver.receiveBridgedReputation(
+        user.address,
+        1,
+        1,
+        42,
+        1_700_000_000,
+        oversizedProof,
+        0
+      )
+    ).to.be.revertedWithCustomError(reputationReceiver, "ProofTooLong");
+  });
+
+  it("accepts a valid one-leaf bridged reputation payload", async function () {
+    const { reputationReceiver, user } = await deployFixture();
+    const score = 42n;
+    const timestamp = 1_700_000_000n;
+    const root = leafFor(user.address, score, timestamp);
+
+    await reputationReceiver.verifySnapshotRoot(1, 1, root);
+
+    await expect(
+      reputationReceiver.receiveBridgedReputation(
+        user.address,
+        1,
+        1,
+        score,
+        timestamp,
+        [],
+        0
+      )
+    )
+      .to.emit(reputationReceiver, "ReputationBridged")
+      .withArgs(user.address, 1, score, anyValue);
+
+    expect(await reputationReceiver.getBridgedReputation(user.address, 1)).to
+      .equal(score);
+  });
+});


### PR DESCRIPTION
## Summary
- Validate `ReputationReceiver` constructor addresses, snapshot roots, and bridged payload fields before proof verification.
- Cap Merkle proof length and reject proof indexes that are impossible for the supplied proof height.
- Add focused regression coverage for malformed bridged reputation payloads and a valid one-leaf payload.
- Add the missing OpenZeppelin upgradeable dependency and minimal compile unblockers required for `hardhat compile` on the current branch.

Closes #160

## Testing
- `npx hardhat compile`
- `npx hardhat test test/ReputationReceiver.test.ts`
- `git diff --check`
- `npm test` currently reaches `105 passing` / `43 failing`; the failures are outside the new `ReputationReceiver` coverage and include stale constructor calls, BigInt mixing in tests, and unrelated assertion drift.

This PR is for Stellar Wave issue #160; please assign/credit @JacKane21 for the bounty if accepted.
