### PR TITLE
Refactor TruthBountyWeighted constants

### DIFF
--- a/contracts/TruthBounty.sol
+++ b/contracts/TruthBounty.sol
@@ -107,6 +107,8 @@ contract TruthBountyToken is ERC20, AccessControl, Initializable, UUPSUpgradeabl
             reason
         );
     }
+
+    function _authorizeUpgrade(address) internal override onlyRole(ADMIN_ROLE) {}
 }
 
 /**

--- a/contracts/TruthBountyWeighted.sol
+++ b/contracts/TruthBountyWeighted.sol
@@ -27,6 +27,45 @@ contract TruthBountyWeighted is AccessControl, ReentrancyGuard, Pausable, Govern
     bytes32 public constant TREASURY_ROLE = keccak256("TREASURY_ROLE");
     bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
 
+    // ============ Protocol Constants ============
+
+    /// @notice Fixed-point precision used by token amounts and reputation scores.
+    uint256 public constant TOKEN_DECIMALS_MULTIPLIER = 10 ** 18;
+
+    /// @notice Base multiplier for reputation scaling (1e18 = 100%).
+    uint256 public constant BASE_MULTIPLIER = TOKEN_DECIMALS_MULTIPLIER;
+
+    /// @notice Denominator for percentage-based governance parameters.
+    uint256 public constant PERCENT_DENOMINATOR = 100;
+
+    /// @notice Default verification window for new claims.
+    uint256 public constant DEFAULT_VERIFICATION_WINDOW_DURATION = 7 days;
+
+    /// @notice Governance bounds for verification window duration.
+    uint256 public constant MIN_VERIFICATION_WINDOW_DURATION = 1 days;
+    uint256 public constant MAX_VERIFICATION_WINDOW_DURATION = 30 days;
+
+    /// @notice Default minimum verifier stake amount.
+    uint256 public constant DEFAULT_MIN_STAKE_AMOUNT = 100 * TOKEN_DECIMALS_MULTIPLIER;
+
+    /// @notice Default settlement threshold percentage.
+    uint256 public constant DEFAULT_SETTLEMENT_THRESHOLD_PERCENT = 60;
+
+    /// @notice Default share of slashed stake distributed to winners.
+    uint256 public constant DEFAULT_REWARD_PERCENT = 80;
+
+    /// @notice Default percentage of losing raw stake that is slashed.
+    uint256 public constant DEFAULT_SLASH_PERCENT = 20;
+
+    /// @notice Minimum reputation score (10% = 0.1x).
+    uint256 public constant MIN_REPUTATION_SCORE = TOKEN_DECIMALS_MULTIPLIER / 10;
+
+    /// @notice Maximum reputation score (1000% = 10x).
+    uint256 public constant MAX_REPUTATION_SCORE = 10 * TOKEN_DECIMALS_MULTIPLIER;
+
+    /// @notice Default reputation for users without a score (100% = 1.0x).
+    uint256 public constant DEFAULT_REPUTATION_SCORE = TOKEN_DECIMALS_MULTIPLIER;
+
     // ============ State Variables ============
 
     /// @notice Token contract for staking and rewards
@@ -37,14 +76,11 @@ contract TruthBountyWeighted is AccessControl, ReentrancyGuard, Pausable, Govern
 
     // ============ Configuration Parameters (Governance-controlled) ============
 
-    uint256 public verificationWindowDuration = 7 days;
-    uint256 public minStakeAmount = 100 * 10**18;
-    uint256 public settlementThresholdPercent = 60;
-    uint256 public rewardPercent = 80;
-    uint256 public slashPercent = 20;
-
-    /// @notice Base multiplier for reputation scaling (1e18 = 100%)
-    uint256 public constant BASE_MULTIPLIER = 1e18;
+    uint256 public verificationWindowDuration = DEFAULT_VERIFICATION_WINDOW_DURATION;
+    uint256 public minStakeAmount = DEFAULT_MIN_STAKE_AMOUNT;
+    uint256 public settlementThresholdPercent = DEFAULT_SETTLEMENT_THRESHOLD_PERCENT;
+    uint256 public rewardPercent = DEFAULT_REWARD_PERCENT;
+    uint256 public slashPercent = DEFAULT_SLASH_PERCENT;
 
     // Governance parameter IDs for reference
     bytes32 public constant GOVERNANCE_PARAM_VERIFICATION_WINDOW = keccak256("VERIFICATION_WINDOW_DURATION");
@@ -54,13 +90,13 @@ contract TruthBountyWeighted is AccessControl, ReentrancyGuard, Pausable, Govern
     bytes32 public constant GOVERNANCE_PARAM_SLASH = keccak256("SLASH_PERCENT");
 
     /// @notice Minimum reputation score (10% = 0.1)
-    uint256 public minReputationScore = 1e17;
+    uint256 public minReputationScore = MIN_REPUTATION_SCORE;
 
     /// @notice Maximum reputation score (1000% = 10x)
-    uint256 public maxReputationScore = 10e18;
+    uint256 public maxReputationScore = MAX_REPUTATION_SCORE;
 
     /// @notice Default reputation for users without a score (100% = 1.0)
-    uint256 public defaultReputationScore = 1e18;
+    uint256 public defaultReputationScore = DEFAULT_REPUTATION_SCORE;
 
     /// @notice Whether weighted staking is enabled
     bool public weightedStakingEnabled = true;
@@ -382,8 +418,6 @@ contract TruthBountyWeighted is AccessControl, ReentrancyGuard, Pausable, Govern
         if (isWinner) {
             stakeToReturn = vote.stakeAmount;
         } else {
-            // Losers get stake back minus slashing (80% of RAW stake)
-            uint256 slashAmount = (vote.stakeAmount * slashPercent) / 100;
             // Losers get stake back minus slashing (pre-calculated at settlement)
             stakeToReturn = vote.stakeAmount - slashAmount;
 
@@ -481,7 +515,7 @@ contract TruthBountyWeighted is AccessControl, ReentrancyGuard, Pausable, Govern
         uint256 totalWeighted = weightedFor + weightedAgainst;
         if (totalWeighted == 0) return false;
 
-        uint256 forPercent = (weightedFor * 100) / totalWeighted;
+        uint256 forPercent = (weightedFor * PERCENT_DENOMINATOR) / totalWeighted;
         return forPercent >= settlementThresholdPercent;
     }
 
@@ -502,13 +536,13 @@ contract TruthBountyWeighted is AccessControl, ReentrancyGuard, Pausable, Govern
         // Calculate total RAW stake from losers for slashing
         uint256 loserRawStake = _calculateLoserRawStake(claimId, passed);
 
-        // Slash 20% of loser's RAW stake
-        slashedAmount = (loserRawStake * slashPercent) / 100;
+        // Slash the configured percentage of losing raw stake.
+        slashedAmount = (loserRawStake * slashPercent) / PERCENT_DENOMINATOR;
         // Calculate and assign per-vote slash amounts, returns total slashed
         slashedAmount = _assignPerVoteSlashes(claimId, passed);
 
-        // 80% of slashed goes to winners as rewards
-        rewardAmount = (slashedAmount * rewardPercent) / 100;
+        // The configured reward share of slashed stake goes to winners.
+        rewardAmount = (slashedAmount * rewardPercent) / PERCENT_DENOMINATOR;
 
         totalSlashed += slashedAmount;
         totalRewarded += rewardAmount;
@@ -540,8 +574,8 @@ contract TruthBountyWeighted is AccessControl, ReentrancyGuard, Pausable, Govern
             bool isLoser = (vote.support != passed);
             
             if (isLoser) {
-                // Calculate slash as 20% of their RAW stake
-                uint256 slashAmount = (vote.stakeAmount * slashPercent) / 100;
+                // Calculate slash as the configured percentage of raw stake.
+                uint256 slashAmount = (vote.stakeAmount * slashPercent) / PERCENT_DENOMINATOR;
                 vote.slashAmount = slashAmount;
                 totalSlashed += slashAmount;
             } else {
@@ -622,7 +656,11 @@ contract TruthBountyWeighted is AccessControl, ReentrancyGuard, Pausable, Govern
      * @param newDuration New duration in seconds
      */
     function setVerificationWindowDuration(uint256 newDuration) external onlyGovernanceOrAdmin {
-        require(newDuration >= 1 days && newDuration <= 30 days, "Invalid duration");
+        require(
+            newDuration >= MIN_VERIFICATION_WINDOW_DURATION
+                && newDuration <= MAX_VERIFICATION_WINDOW_DURATION,
+            "Invalid duration"
+        );
         
         uint256 oldDuration = verificationWindowDuration;
         verificationWindowDuration = newDuration;
@@ -648,7 +686,7 @@ contract TruthBountyWeighted is AccessControl, ReentrancyGuard, Pausable, Govern
      * @param newThreshold New threshold (1-100)
      */
     function setSettlementThresholdPercent(uint256 newThreshold) external onlyGovernanceOrAdmin {
-        require(newThreshold > 0 && newThreshold <= 100, "Invalid threshold");
+        require(newThreshold > 0 && newThreshold <= PERCENT_DENOMINATOR, "Invalid threshold");
         
         uint256 old = settlementThresholdPercent;
         settlementThresholdPercent = newThreshold;
@@ -661,7 +699,7 @@ contract TruthBountyWeighted is AccessControl, ReentrancyGuard, Pausable, Govern
      * @param newPercent New reward percent (1-100)
      */
     function setRewardPercent(uint256 newPercent) external onlyGovernanceOrAdmin {
-        require(newPercent > 0 && newPercent <= 100, "Invalid percent");
+        require(newPercent > 0 && newPercent <= PERCENT_DENOMINATOR, "Invalid percent");
         
         uint256 old = rewardPercent;
         rewardPercent = newPercent;
@@ -674,7 +712,7 @@ contract TruthBountyWeighted is AccessControl, ReentrancyGuard, Pausable, Govern
      * @param newPercent New slash percent (1-100)
      */
     function setSlashPercent(uint256 newPercent) external onlyGovernanceOrAdmin {
-        require(newPercent > 0 && newPercent <= 100, "Invalid percent");
+        require(newPercent > 0 && newPercent <= PERCENT_DENOMINATOR, "Invalid percent");
         
         uint256 old = slashPercent;
         slashPercent = newPercent;

--- a/contracts/governance/GovernanceController.sol
+++ b/contracts/governance/GovernanceController.sol
@@ -68,9 +68,9 @@ contract GovernanceController is GovernorAccessControl, ReentrancyGuard, Governa
 
     // ============ Modifiers ============
     
-    modifier onlyProposalExecutor() {
+    modifier onlyProposalExecutor() override {
         if (!hasRole(GovernorAccess.PROPOSAL_EXECUTOR_ROLE, msg.sender)) {
-            revert AccessControl.AccessDenied();
+            revert GovernorAccess.AccessDenied(msg.sender);
         }
         _;
     }

--- a/contracts/governance/GovernorAccess.sol
+++ b/contracts/governance/GovernorAccess.sol
@@ -180,7 +180,7 @@ abstract contract GovernorAccessControl is AccessControl {
         _;
     }
     
-    modifier onlyProposalExecutor() {
+    modifier onlyProposalExecutor() virtual {
         if (!hasRole(GovernorAccess.PROPOSAL_EXECUTOR_ROLE, msg.sender) && 
             !hasRole(DEFAULT_ADMIN_ROLE, msg.sender)) {
             revert GovernorAccess.NotProposalExecutor(msg.sender);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,14 @@
       "license": "ISC",
       "dependencies": {
         "@openzeppelin/contracts": "^5.4.0",
+        "@openzeppelin/contracts-upgradeable": "^5.4.0",
         "dotenv": "^16.4.7"
       },
       "devDependencies": {
         "@nomicfoundation/hardhat-chai-matchers": "^2.1.2",
         "@nomicfoundation/hardhat-ethers": "^3.1.3",
-        "@nomicfoundation/hardhat-ignition": "^3.0.7",
-        "@nomicfoundation/hardhat-ignition-ethers": "^3.0.7",
+        "@nomicfoundation/hardhat-ignition": "^0.15.16",
+        "@nomicfoundation/hardhat-ignition-ethers": "^0.15.16",
         "@nomicfoundation/hardhat-network-helpers": "^1.1.2",
         "@nomicfoundation/hardhat-toolbox": "^5.0.0",
         "@nomicfoundation/hardhat-verify": "^2.1.3",
@@ -1612,16 +1613,6 @@
         "hardhat": "^2.26.0"
       }
     },
-    "node_modules/@nomicfoundation/hardhat-errors": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-errors/-/hardhat-errors-3.0.9.tgz",
-      "integrity": "sha512-qwKMpPsTI0q2Q5w3SKh231WZZPyCHjUvlbUivAn8zNeQ7ko59nBqWoiwMNRuq4F0zVaO1XZ3863R8HwyNd/n0A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nomicfoundation/hardhat-utils": "^4.0.1"
-      }
-    },
     "node_modules/@nomicfoundation/hardhat-ethers": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ethers/-/hardhat-ethers-3.1.3.tgz",
@@ -1638,42 +1629,75 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-ignition": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition/-/hardhat-ignition-3.1.0.tgz",
-      "integrity": "sha512-ENZcVz/L5cpxhtJhglN3nY9gYeMex9aJddOsMpcD+6xQqSwFcEslgJjXXCVJsjhtzDJC2UGBJT2DbpYWV1jILA==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition/-/hardhat-ignition-0.15.16.tgz",
+      "integrity": "sha512-T0JTnuib7QcpsWkHCPLT7Z6F483EjTdcdjb1e00jqS9zTGCPqinPB66LLtR/duDLdvgoiCVS6K8WxTQkA/xR1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/hardhat-errors": "^3.0.9",
-        "@nomicfoundation/hardhat-utils": "^4.0.0",
-        "@nomicfoundation/ignition-core": "^3.1.0",
-        "@nomicfoundation/ignition-ui": "^3.1.0",
-        "chalk": "^5.3.0",
+        "@nomicfoundation/ignition-core": "^0.15.15",
+        "@nomicfoundation/ignition-ui": "^0.15.13",
+        "chalk": "^4.0.0",
         "debug": "^4.3.2",
+        "fs-extra": "^10.0.0",
         "json5": "^2.2.3",
         "prompts": "^2.4.2"
       },
       "peerDependencies": {
-        "@nomicfoundation/hardhat-verify": "^3.0.0",
-        "hardhat": "^3.1.5"
+        "@nomicfoundation/hardhat-verify": "^2.1.0",
+        "hardhat": "^2.26.0"
       }
     },
     "node_modules/@nomicfoundation/hardhat-ignition-ethers": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition-ethers/-/hardhat-ignition-ethers-3.1.0.tgz",
-      "integrity": "sha512-Z/qVJVYObdJLpYZB2sSU6VdqQZRClefe5CQXyUGAGKALKSObcOU2d8V5Pe+d/uune50C47XkTmwAWRRf9gHx4A==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition-ethers/-/hardhat-ignition-ethers-0.15.16.tgz",
+      "integrity": "sha512-OXC1jLX06YFgzFero9AjHUSwB39CLWPiBAJj5ZoDJiTnAbH1DvnQSt8sUJuZRrrL+WH8sQbcB4hjkPcR0B5hAA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@nomicfoundation/hardhat-ethers": "^3.1.0",
+        "@nomicfoundation/hardhat-ignition": "^0.15.15",
+        "@nomicfoundation/ignition-core": "^0.15.14",
+        "ethers": "^6.14.0",
+        "hardhat": "^2.26.0"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-ignition/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/hardhat-errors": "^3.0.9"
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
       },
-      "peerDependencies": {
-        "@nomicfoundation/hardhat-ethers": "^4.0.0",
-        "@nomicfoundation/hardhat-ignition": "^3.0.7",
-        "@nomicfoundation/hardhat-verify": "^3.0.0",
-        "@nomicfoundation/ignition-core": "^3.0.7",
-        "ethers": "^6.14.0",
-        "hardhat": "^3.1.5"
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-ignition/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-ignition/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/@nomicfoundation/hardhat-network-helpers": {
@@ -1716,23 +1740,6 @@
         "typescript": ">=4.5.0"
       }
     },
-    "node_modules/@nomicfoundation/hardhat-utils": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-utils/-/hardhat-utils-4.0.1.tgz",
-      "integrity": "sha512-9xxD6WXLn+kopd+hmF+XYcJJ38Gm06QmZxKf/fIJzlzs9FuNI6C7Lvdd4qHv8/3ReegIbpBCrzozaL2GISmNrA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@streamparser/json-node": "^0.0.22",
-        "debug": "^4.3.2",
-        "env-paths": "^2.2.0",
-        "ethereum-cryptography": "^2.2.1",
-        "fast-equals": "^5.4.0",
-        "json-stream-stringify": "^3.1.6",
-        "rfdc": "^1.3.1",
-        "undici": "^6.16.1"
-      }
-    },
     "node_modules/@nomicfoundation/hardhat-verify": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-verify/-/hardhat-verify-2.1.3.tgz",
@@ -1768,29 +1775,87 @@
       }
     },
     "node_modules/@nomicfoundation/ignition-core": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-core/-/ignition-core-3.1.0.tgz",
-      "integrity": "sha512-RJMBTBZqiWRT6lP0sWr2QoIogS0czCioxF4wYW8Y6PowipQKg/usvfJEbzcIEkTIbqOPBZbA7WGINr8YKIoJAA==",
+      "version": "0.15.15",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-core/-/ignition-core-0.15.15.tgz",
+      "integrity": "sha512-JdKFxYknTfOYtFXMN6iFJ1vALJPednuB+9p9OwGIRdoI6HYSh4ZBzyRURgyXtHFyaJ/SF9lBpsYV9/1zEpcYwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ethersproject/address": "5.6.1",
-        "@nomicfoundation/hardhat-errors": "^3.0.9",
-        "@nomicfoundation/hardhat-utils": "^4.0.0",
         "@nomicfoundation/solidity-analyzer": "^0.1.1",
-        "cbor2": "^1.9.0",
+        "cbor": "^9.0.0",
         "debug": "^4.3.2",
         "ethers": "^6.14.0",
+        "fs-extra": "^10.0.0",
         "immer": "10.0.2",
-        "lodash-es": "4.17.21",
+        "lodash": "4.17.21",
         "ndjson": "2.0.0"
       }
     },
+    "node_modules/@nomicfoundation/ignition-core/node_modules/cbor": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-9.0.2.tgz",
+      "integrity": "sha512-JPypkxsB10s9QOWwa6zwPzqE1Md3vqpPc+cai4sAecuCsRyAtAl/pMyhPlMbT/xtPnm2dznJZYRLui57qiRhaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "nofilter": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@nomicfoundation/ignition-core/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@nomicfoundation/ignition-core/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@nomicfoundation/ignition-core/node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@nomicfoundation/ignition-core/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@nomicfoundation/ignition-ui": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-ui/-/ignition-ui-3.1.0.tgz",
-      "integrity": "sha512-K34qH+C0IgerzzcY+OmLlXvAnpE1TGKRlDRDE0IfyhjB/ueDJj83+5+YhoPbCiwDFIl7uT7vaWopfFhkRPn9YQ==",
-      "dev": true
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-ui/-/ignition-ui-0.15.13.tgz",
+      "integrity": "sha512-HbTszdN1iDHCkUS9hLeooqnLEW2U45FaqFwFEYT8nIno2prFZhG+n68JEERjmfFCB5u0WgbuJwk3CgLoqtSL7Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@nomicfoundation/slang": {
       "version": "0.18.3",
@@ -1899,10 +1964,19 @@
       }
     },
     "node_modules/@openzeppelin/contracts": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.6.1.tgz",
-      "integrity": "sha512-Ly6SlsVJ3mj+b18W3R8gNufB7dTICT105fJhodGAGgyC2oqnBAhqSiNDJ8V8DLY05cCz81GLI0CU5vNYA1EC/w==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.4.0.tgz",
+      "integrity": "sha512-eCYgWnLg6WO+X52I16TZt8uEjbtdkgLC0SUX/xnAksjjrQI4Xfn4iBRoI5j55dmlOhDv1Y7BoR3cU7e3WWhC6A==",
       "license": "MIT"
+    },
+    "node_modules/@openzeppelin/contracts-upgradeable": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-5.4.0.tgz",
+      "integrity": "sha512-STJKyDzUcYuB35Zub1JpWW58JxvrFFVgQ+Ykdr8A9PGXgtq/obF5uoh07k2XmFyPxfnZdPdBdhkJ/n2YxJ87HQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@openzeppelin/contracts": "5.4.0"
+      }
     },
     "node_modules/@openzeppelin/defender-sdk-base-client": {
       "version": "2.7.1",
@@ -1973,36 +2047,6 @@
         }
       }
     },
-    "node_modules/@openzeppelin/hardhat-upgrades/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@openzeppelin/hardhat-upgrades/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@openzeppelin/upgrades-core": {
       "version": "1.44.2",
       "resolved": "https://registry.npmjs.org/@openzeppelin/upgrades-core/-/upgrades-core-1.44.2.tgz",
@@ -2037,36 +2081,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/@openzeppelin/upgrades-core/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@openzeppelin/upgrades-core/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -2988,23 +3002,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@streamparser/json": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/@streamparser/json/-/json-0.0.22.tgz",
-      "integrity": "sha512-b6gTSBjJ8G8SuO3Gbbj+zXbVx8NSs1EbpbMKpzGLWMdkR+98McH9bEjSz3+0mPJf68c5nxa3CrJHp5EQNXM6zQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@streamparser/json-node": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/@streamparser/json-node/-/json-node-0.0.22.tgz",
-      "integrity": "sha512-sJT2ptNRwqB1lIsQrQlCoWk5rF4tif9wDh+7yluAGijJamAhrHGYpFB/Zg3hJeceoZypi74ftXk8DHzwYpbZSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@streamparser/json": "^0.0.22"
-      }
-    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
@@ -3675,36 +3672,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/boxen/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/boxen/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/boxen/node_modules/type-fest": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
@@ -3918,16 +3885,6 @@
         "node": ">=12.19"
       }
     },
-    "node_modules/cbor2": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/cbor2/-/cbor2-1.12.0.tgz",
-      "integrity": "sha512-3Cco8XQhi27DogSp9Ri6LYNZLi/TBY/JVnDe+mj06NkBjW/ZYOtekaEU4wZ4xcRMNrFkDv8KNtOAqHyDfz3lYg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.7"
-      }
-    },
     "node_modules/chai": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
@@ -3961,16 +3918,33 @@
       }
     },
     "node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
       "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/charenc": {
@@ -4916,16 +4890,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-equals": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
-      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -5633,36 +5597,6 @@
       },
       "peerDependencies": {
         "hardhat": "^2.16.0"
-      }
-    },
-    "node_modules/hardhat-gas-reporter/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/hardhat-gas-reporter/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/hardhat/node_modules/@noble/hashes": {
@@ -6415,13 +6349,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -6466,36 +6393,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-symbols/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/log-symbols/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/loupe": {
@@ -7683,13 +7580,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rfdc": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
-      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/ripemd160": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
@@ -8703,36 +8593,6 @@
       },
       "bin": {
         "write-markdown": "dist/write-markdown.js"
-      }
-    },
-    "node_modules/ts-command-line-args/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/ts-command-line-args/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/ts-essentials": {

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   "devDependencies": {
     "@nomicfoundation/hardhat-chai-matchers": "^2.1.2",
     "@nomicfoundation/hardhat-ethers": "^3.1.3",
-    "@nomicfoundation/hardhat-ignition": "^3.0.7",
-    "@nomicfoundation/hardhat-ignition-ethers": "^3.0.7",
+    "@nomicfoundation/hardhat-ignition": "^0.15.16",
+    "@nomicfoundation/hardhat-ignition-ethers": "^0.15.16",
     "@nomicfoundation/hardhat-network-helpers": "^1.1.2",
     "@nomicfoundation/hardhat-toolbox": "^5.0.0",
     "@nomicfoundation/hardhat-verify": "^2.1.3",
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "@openzeppelin/contracts": "^5.4.0",
+    "@openzeppelin/contracts-upgradeable": "^5.4.0",
     "dotenv": "^16.4.7"
   }
 }

--- a/test/TruthBountyWeighted.test.ts
+++ b/test/TruthBountyWeighted.test.ts
@@ -17,6 +17,7 @@ describe("TruthBountyWeighted", function () {
   const INITIAL_SUPPLY = ethers.parseEther("1000000");
   const MIN_STAKE = ethers.parseEther("100");
   const VERIFICATION_WINDOW = 7 * 24 * 60 * 60; // 7 days
+  const PERCENT_DENOMINATOR = 100n;
 
   beforeEach(async function () {
     [owner, submitter, verifier1, verifier2, verifier3] = await ethers.getSigners();
@@ -63,6 +64,51 @@ describe("TruthBountyWeighted", function () {
 
     it("Should have weighted staking enabled by default", async function () {
       expect(await truthBounty.weightedStakingEnabled()).to.equal(true);
+    });
+
+    it("Should expose named constants for weighted staking defaults", async function () {
+      expect(await truthBounty.TOKEN_DECIMALS_MULTIPLIER()).to.equal(ethers.parseEther("1"));
+      expect(await truthBounty.BASE_MULTIPLIER()).to.equal(
+        await truthBounty.TOKEN_DECIMALS_MULTIPLIER()
+      );
+      expect(await truthBounty.PERCENT_DENOMINATOR()).to.equal(PERCENT_DENOMINATOR);
+      expect(await truthBounty.DEFAULT_VERIFICATION_WINDOW_DURATION()).to.equal(
+        BigInt(VERIFICATION_WINDOW)
+      );
+      expect(await truthBounty.MIN_VERIFICATION_WINDOW_DURATION()).to.equal(BigInt(24 * 60 * 60));
+      expect(await truthBounty.MAX_VERIFICATION_WINDOW_DURATION()).to.equal(
+        BigInt(30 * 24 * 60 * 60)
+      );
+      expect(await truthBounty.DEFAULT_MIN_STAKE_AMOUNT()).to.equal(MIN_STAKE);
+      expect(await truthBounty.DEFAULT_SETTLEMENT_THRESHOLD_PERCENT()).to.equal(60n);
+      expect(await truthBounty.DEFAULT_REWARD_PERCENT()).to.equal(80n);
+      expect(await truthBounty.DEFAULT_SLASH_PERCENT()).to.equal(20n);
+      expect(await truthBounty.MIN_REPUTATION_SCORE()).to.equal(ethers.parseEther("0.1"));
+      expect(await truthBounty.MAX_REPUTATION_SCORE()).to.equal(ethers.parseEther("10"));
+      expect(await truthBounty.DEFAULT_REPUTATION_SCORE()).to.equal(ethers.parseEther("1"));
+    });
+
+    it("Should initialize configurable parameters from named defaults", async function () {
+      expect(await truthBounty.verificationWindowDuration()).to.equal(
+        await truthBounty.DEFAULT_VERIFICATION_WINDOW_DURATION()
+      );
+      expect(await truthBounty.minStakeAmount()).to.equal(
+        await truthBounty.DEFAULT_MIN_STAKE_AMOUNT()
+      );
+      expect(await truthBounty.settlementThresholdPercent()).to.equal(
+        await truthBounty.DEFAULT_SETTLEMENT_THRESHOLD_PERCENT()
+      );
+      expect(await truthBounty.rewardPercent()).to.equal(await truthBounty.DEFAULT_REWARD_PERCENT());
+      expect(await truthBounty.slashPercent()).to.equal(await truthBounty.DEFAULT_SLASH_PERCENT());
+      expect(await truthBounty.minReputationScore()).to.equal(
+        await truthBounty.MIN_REPUTATION_SCORE()
+      );
+      expect(await truthBounty.maxReputationScore()).to.equal(
+        await truthBounty.MAX_REPUTATION_SCORE()
+      );
+      expect(await truthBounty.defaultReputationScore()).to.equal(
+        await truthBounty.DEFAULT_REPUTATION_SCORE()
+      );
     });
   });
 
@@ -308,6 +354,31 @@ describe("TruthBountyWeighted", function () {
 
       expect(reward1).to.be.closeTo(verifier1RewardShare, ethers.parseEther("0.01"));
       expect(reward2).to.be.closeTo(verifier2RewardShare, ethers.parseEther("0.01"));
+    });
+
+    it("Should preserve settlement-time slash amounts when governance parameters change", async function () {
+      const stakeAmount = ethers.parseEther("100");
+
+      await truthBounty.connect(verifier1).vote(claimId, true, stakeAmount);
+      await truthBounty.connect(verifier2).vote(claimId, false, stakeAmount);
+
+      await time.increase(VERIFICATION_WINDOW + 1);
+      await truthBounty.settleClaim(claimId);
+
+      const losingVote = await truthBounty.getVote(claimId, await verifier2.getAddress());
+      expect(losingVote.slashAmount).to.equal(ethers.parseEther("20"));
+
+      await truthBounty.setSlashPercent(100);
+
+      const balanceBefore = await bountyToken.balanceOf(await verifier2.getAddress());
+      await truthBounty.connect(verifier2).withdrawSettledStake(claimId);
+      const balanceAfter = await bountyToken.balanceOf(await verifier2.getAddress());
+
+      expect(balanceAfter - balanceBefore).to.equal(ethers.parseEther("80"));
+
+      const verifierStake = await truthBounty.getVerifierStake(await verifier2.getAddress());
+      expect(verifierStake.totalStaked).to.equal(ethers.parseEther("980"));
+      expect(verifierStake.activeStakes).to.equal(0);
     });
   });
 

--- a/test/TruthBountyWeighted.test.ts
+++ b/test/TruthBountyWeighted.test.ts
@@ -365,18 +365,18 @@ describe("TruthBountyWeighted", function () {
       await time.increase(VERIFICATION_WINDOW + 1);
       await truthBounty.settleClaim(claimId);
 
-      const losingVote = await truthBounty.getVote(claimId, await verifier2.getAddress());
+      const losingVote = await truthBounty.getVote(claimId, await verifier1.getAddress());
       expect(losingVote.slashAmount).to.equal(ethers.parseEther("20"));
 
       await truthBounty.setSlashPercent(100);
 
-      const balanceBefore = await bountyToken.balanceOf(await verifier2.getAddress());
-      await truthBounty.connect(verifier2).withdrawSettledStake(claimId);
-      const balanceAfter = await bountyToken.balanceOf(await verifier2.getAddress());
+      const balanceBefore = await bountyToken.balanceOf(await verifier1.getAddress());
+      await truthBounty.connect(verifier1).withdrawSettledStake(claimId);
+      const balanceAfter = await bountyToken.balanceOf(await verifier1.getAddress());
 
       expect(balanceAfter - balanceBefore).to.equal(ethers.parseEther("80"));
 
-      const verifierStake = await truthBounty.getVerifierStake(await verifier2.getAddress());
+      const verifierStake = await truthBounty.getVerifierStake(await verifier1.getAddress());
       expect(verifierStake.totalStaked).to.equal(ethers.parseEther("980"));
       expect(verifierStake.activeStakes).to.equal(0);
     });


### PR DESCRIPTION
## Summary
- replace hardcoded TruthBountyWeighted scale, percentage, window, stake, and reputation defaults with named public constants
- initialize configurable parameters from those constants and reuse the percentage denominator in calculations/guards
- preserve settlement-time slash amounts when governance parameters change after settlement
- add tests covering exposed constants, default initialization, and the settlement-time slash invariant
- fix repo setup blockers that prevented Hardhat verification: add the missing OpenZeppelin upgradeable dependency, align Hardhat Ignition with Hardhat 2/toolbox, and repair compile errors in the upgrade/governance scaffolding

Closes #182

## Verification
- git diff --check
- npm run compile
- npm test -- --grep "TruthBountyWeighted" (29 passing)
- npm test (103 passing, 43 failing in unrelated pre-existing suites: stale constructor arguments, legacy revert expectations, EIP712 replay expectation, and upgrade proxy argument setup)