### PR TITLE
fix: implement mutable bountyToken mechanism with unit tests

### DIFF
--- a/contracts/TruthBountyWeighted.sol
+++ b/contracts/TruthBountyWeighted.sol
@@ -30,7 +30,7 @@ contract TruthBountyWeighted is AccessControl, ReentrancyGuard, Pausable, Govern
     // ============ State Variables ============
 
     /// @notice Token contract for staking and rewards
-    IERC20 public immutable bountyToken;
+    IERC20 public bountyToken;
 
     /// @notice Reputation oracle for score lookups
     IReputationOracle public reputationOracle;
@@ -716,4 +716,14 @@ contract TruthBountyWeighted is AccessControl, ReentrancyGuard, Pausable, Govern
     function unpause() external onlyRole(PAUSER_ROLE) {
         _unpause();
     }
+/// @notice Safely migrates the primary payment bounty token
+/// @param _newBountyToken The address of the new ERC20 token
+function updateBountyToken(address _newBountyToken) external {
+    require(msg.sender == owner, "Unauthorized");
+    require(_newBountyToken != address(0), "Invalid token address");
+    require(_newBountyToken != address(bountyToken), "Token already active");
+
+    bountyToken = IERC20(_newBountyToken);
+}
+
 }

--- a/test/TruthBountyWeighted.test.ts
+++ b/test/TruthBountyWeighted.test.ts
@@ -476,4 +476,27 @@ describe("TruthBountyWeighted", function () {
       expect(vote.reputationScore).to.equal(ethers.parseEther("1")); // Default
     });
   });
+    describe("BountyToken Change Mechanism", function () {
+    it("Should allow the owner to update the bounty token address", async function () {
+      const TruthBountyTokenFactory = await ethers.getContractFactory("TruthBountyToken");
+      const newToken = await TruthBountyTokenFactory.deploy();
+      await newToken.waitForDeployment();
+
+      // Directly execute the change mechanism
+      await truthBounty.updateBountyToken(await newToken.getAddress());
+        
+      expect(await truthBounty.bountyToken()).to.equal(await newToken.getAddress());
+    });
+
+    it("Should fail if a non-owner tries to update the bounty token address", async function () {
+      const randomAddress = "0x0000000000000000000000000000000000000001";
+      
+      await expect(
+        truthBounty.connect(verifier1).updateBountyToken(randomAddress)
+      ).to.be.revertedWith("Unauthorized");
+    });
+  });
+
+  });
+
 });


### PR DESCRIPTION
### Summary
Addresses issue #197 by implementing a secure bountyToken change mechanism.

### What was done:
- Removed the `immutable` restriction from the `bountyToken` state variable declaration.
- Implemented an administrative `updateBountyToken` migration function protected by an owner authorization gate.
- Appended a localized unit test suite inside `test/TruthBountyWeighted.test.ts` to confirm valid state mutations and unauthorized failure constraints.
