### PR TITLE
fix(governance): add missing __gap storage slot to GovernanceOwnable

### DIFF
--- a/contracts/governance/GovernanceOwnable.sol
+++ b/contracts/governance/GovernanceOwnable.sol
@@ -233,4 +233,9 @@ abstract contract GovernanceOwnable is AccessControl, Pausable {
     function getGovernanceVersion() external view returns (uint256) {
         return 1; // Placeholder for future governance version tracking
     }
+
+    // ============ Reserved Storage ============
+
+    /// @dev Storage gap for future upgrades (reserved 50 slots)
+    uint256[50] private __gap;
 }

--- a/test/governance/GovernanceOwnable.t.sol
+++ b/test/governance/GovernanceOwnable.t.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../contracts/governance/GovernanceOwnable.sol";
+
+contract GovernanceOwnableMock is GovernanceOwnable {
+    uint256 public nextValue;
+
+    constructor(address admin, address emergencyAdmin_) {
+        _initializeGovernance(address(0), admin, emergencyAdmin_);
+    }
+
+    function setValue(uint256 newValue) external onlyGovernanceOrAdmin {
+        nextValue = newValue;
+    }
+}
+
+contract GovernanceOwnableTest is Test {
+    GovernanceOwnableMock public govOwnable;
+    address public admin = address(0x1);
+    address public emergencyAdmin_ = address(0x2);
+
+    function setUp() public {
+        govOwnable = new GovernanceOwnableMock(admin, emergencyAdmin_);
+    }
+
+    function test_Gap_SlotsReserved() public {
+        uint256 gapStartSlot = 4;
+
+        for (uint256 i = 0; i < 50; i++) {
+            bytes32 slotValue = vm.load(address(govOwnable), bytes32(uint256(gapStartSlot + i)));
+            assertEq(uint256(slotValue), 0, "gap slot should be uninitialized");
+        }
+    }
+
+    function test_Gap_StateVariablesAccessible() public {
+        assertEq(govOwnable.governanceController(), address(0));
+        assertEq(govOwnable.governanceEnabled(), true);
+        assertEq(govOwnable.emergencyAdmin(), emergencyAdmin_);
+    }
+
+    function test_Gap_DoesNotBreakAdminFunctions() public {
+        vm.prank(admin);
+        govOwnable.setValue(42);
+        assertEq(govOwnable.nextValue(), 42);
+    }
+
+    function test_Gap_DoesNotBreakPause() public {
+        vm.prank(emergencyAdmin_);
+        govOwnable.emergencyPause();
+        assertTrue(govOwnable.paused());
+
+        vm.prank(emergencyAdmin_);
+        govOwnable.emergencyUnpause();
+        assertFalse(govOwnable.paused());
+    }
+
+    function test_Gap_DoesNotBreakGovernanceController() public {
+        vm.prank(admin);
+        govOwnable.setGovernanceController(address(0x3));
+        assertEq(govOwnable.governanceController(), address(0x3));
+    }
+}


### PR DESCRIPTION
## Description

Adds a `uint256[50] private __gap` storage reservation to `GovernanceOwnable`
following the standard OpenZeppelin upgradeable contract pattern.

## Problem

`GovernanceOwnable` is inherited by `VerifierSlashing`, `WeightedStaking`,
`TruthBountyWeighted`, and `TruthBounty`. Without a storage gap, any future
state variable added to `GovernanceOwnable` would shift the storage layout of
every derived contract, causing silent data corruption.

## Solution

- Added `uint256[50] private __gap` at the end of `GovernanceOwnable` (after
  `getGovernanceVersion()`), reserving 50 storage slots for future use.
- Added Foundry unit tests verifying the gap slots are zero, existing state
  variables remain accessible, and core functionality (pause, admin functions,
  governance controller updates) is unaffected.

Closes #162