### PR TITLE
Implement TruthBounty ETH receive/rescue logic and add tests

### DIFF
--- a/contracts/TruthBounty.sol
+++ b/contracts/TruthBounty.sol
@@ -205,6 +205,8 @@ contract TruthBounty is AccessControl, ReentrancyGuard, Pausable, GovernanceOwna
     event StakeDeposited(address indexed verifier, uint256 amount);
     event StakeWithdrawn(address indexed verifier, uint256 amount);
     event RewardsClaimed(address indexed verifier, uint256 amount);
+    event ETHReceived(address indexed sender, uint256 amount);
+    event ETHRescued(address indexed recipient, uint256 amount);
 
     constructor(address _bountyToken, address initialAdmin, address _governanceController) {
         require(_bountyToken != address(0), "Invalid token address");
@@ -392,6 +394,25 @@ contract TruthBounty is AccessControl, ReentrancyGuard, Pausable, GovernanceOwna
         require(bountyToken.transfer(msg.sender, amount), "Transfer failed");
 
         emit StakeWithdrawn(msg.sender, amount);
+    }
+
+    function rescueETH(address payable to, uint256 amount) external onlyRole(TREASURY_ROLE) nonReentrant {
+        require(to != address(0), "Invalid recipient");
+        require(amount > 0, "Amount must be > 0");
+        require(address(this).balance >= amount, "Insufficient ETH balance");
+
+        (bool success, ) = to.call{value: amount}("");
+        require(success, "ETH transfer failed");
+
+        emit ETHRescued(to, amount);
+    }
+
+    receive() external payable {
+        emit ETHReceived(msg.sender, msg.value);
+    }
+
+    fallback() external payable {
+        emit ETHReceived(msg.sender, msg.value);
     }
 
     function getClaim(uint256 claimId) external view returns (Claim memory) {

--- a/test/TruthBounty.test.ts
+++ b/test/TruthBounty.test.ts
@@ -4,18 +4,28 @@ import { Contract, Signer } from "ethers";
 
 describe("TruthBountyToken Legacy & Role Tests", function () {
     let token: Contract;
+    let truthBounty: Contract;
     let owner: Signer;
     let addr1: Signer;
     let addr2: Signer;
+    let governanceController: Signer;
 
     const INITIAL_SUPPLY = ethers.parseEther("10000000");
 
     beforeEach(async function () {
-        [owner, addr1, addr2] = await ethers.getSigners();
+        [owner, addr1, addr2, governanceController] = await ethers.getSigners();
 
         const TruthBountyTokenFactory = await ethers.getContractFactory("TruthBountyToken");
         token = await TruthBountyTokenFactory.deploy(await owner.getAddress());
         await token.waitForDeployment();
+
+        const TruthBountyFactory = await ethers.getContractFactory("TruthBounty");
+        truthBounty = await TruthBountyFactory.deploy(
+            await token.getAddress(),
+            await owner.getAddress(),
+            await governanceController.getAddress()
+        );
+        await truthBounty.waitForDeployment();
     });
 
     describe("Deployment", function () {
@@ -69,6 +79,43 @@ describe("TruthBountyToken Legacy & Role Tests", function () {
         it("Should fail if unstaking more than staked legacy way", async function () {
             const stakeAmount = ethers.parseEther("100");
             await expect(token.connect(addr1).withdrawStake(stakeAmount)).to.be.revertedWith("Insufficient stake");
+        });
+    });
+
+    describe("ETH Transfer Logic", function () {
+        it("Should accept Ether via receive", async function () {
+            const amount = ethers.parseEther("1");
+            await owner.sendTransaction({ to: await truthBounty.getAddress(), value: amount });
+
+            expect(await ethers.provider.getBalance(await truthBounty.getAddress())).to.equal(amount);
+        });
+
+        it("Should allow TREASURY_ROLE to rescue Ether", async function () {
+            const amount = ethers.parseEther("1");
+            const treasuryRole = await truthBounty.TREASURY_ROLE();
+            await truthBounty.grantRole(treasuryRole, await owner.getAddress());
+
+            await owner.sendTransaction({ to: await truthBounty.getAddress(), value: amount });
+            expect(await ethers.provider.getBalance(await truthBounty.getAddress())).to.equal(amount);
+
+            const recipient = await addr1.getAddress();
+            const balanceBefore = await ethers.provider.getBalance(recipient);
+
+            await expect(truthBounty.rescueETH(recipient, amount))
+                .to.emit(truthBounty, "ETHRescued")
+                .withArgs(recipient, amount);
+
+            expect(await ethers.provider.getBalance(await truthBounty.getAddress())).to.equal(0);
+            expect(await ethers.provider.getBalance(recipient)).to.equal(balanceBefore + amount);
+        });
+
+        it("Should revert rescueETH for unauthorized caller", async function () {
+            const amount = ethers.parseEther("1");
+            await owner.sendTransaction({ to: await truthBounty.getAddress(), value: amount });
+
+            await expect(
+                truthBounty.connect(addr1).rescueETH(await addr1.getAddress(), amount)
+            ).to.be.revertedWith(/AccessControl/);
         });
     });
 });

--- a/test/invariant/TruthBountyInvariant.t.sol
+++ b/test/invariant/TruthBountyInvariant.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "forge-std/StdInvariant.sol";
+import "../../contracts/TruthBounty.sol";
+
+contract TruthBountyInvariant is StdInvariant, Test {
+    TruthBounty public truthBounty;
+    TruthBountyToken public token;
+
+    function setUp() public {
+        token = new TruthBountyToken(address(this));
+        truthBounty = new TruthBounty(address(token), address(this), address(this));
+
+        targetContract(address(truthBounty));
+    }
+
+    function invariant_TotalRewardedNeverExceedsTotalSlashed() public view {
+        assertLe(truthBounty.totalRewarded(), truthBounty.totalSlashed());
+    }
+
+    function invariant_ContractEthBalanceIsNonNegative() public view {
+        assertGe(address(truthBounty).balance, 0);
+    }
+}


### PR DESCRIPTION
Closes #163
Implement TruthBounty ETH receive/rescue logic and add tests
Files included:
[TruthBounty.sol](https://humble-space-acorn-7vq7746g47w7fq4x.github.dev/)
[TruthBounty.test.ts](https://humble-space-acorn-7vq7746g47w7fq4x.github.dev/)
[TruthBountyInvariant.t.sol](https://humble-space-acorn-7vq7746g47w7fq4x.github.dev/)