### PR TITLE
fix(#190): rename internal _settle params to avoid shadowing

### DIFF
--- a/contracts/TruthBountyClaims.sol
+++ b/contracts/TruthBountyClaims.sol
@@ -81,15 +81,17 @@ contract TruthBountyClaims is AccessControl, ReentrancyGuard {
 
     /**
      * @dev Internal function to handle the transfer logic.
+     *      Parameters use an underscore prefix to avoid any potential
+     *      shadowing with inherited declarations (Audit #190).
      */
-    function _settle(address beneficiary, uint256 amount) internal {
-        require(beneficiary != address(0), "Invalid beneficiary");
-        require(amount > 0, "Amount must be > 0");
+    function _settle(address _beneficiary, uint256 _amount) internal {
+        require(_beneficiary != address(0), "Invalid beneficiary");
+        require(_amount > 0, "Amount must be > 0");
 
         // The contract must hold enough tokens to cover the transfer
-        bountyToken.safeTransfer(beneficiary, amount);
+        bountyToken.safeTransfer(_beneficiary, _amount);
 
-        emit ClaimSettled(beneficiary, amount);
+        emit ClaimSettled(_beneficiary, _amount);
     }
 
     /**

--- a/test/TruthBountyClaims.test.ts
+++ b/test/TruthBountyClaims.test.ts
@@ -50,6 +50,33 @@ describe("TruthBountyClaims", function () {
     expect(await token.balanceOf(user.address)).to.equal(a1);
     expect(await token.balanceOf(other.address)).to.equal(a2);
   });
+
+  // Audit #190: ensures renamed internal _settle params do not shadow
+  // event/storage identifiers and that single + batch paths still emit
+  // the correct indexed args and token amounts.
+  it("does not introduce shadowing: ClaimSettled args match across single and batch paths", async function () {
+    const { admin, user, other, token, claims } = await loadFixture(deployFixture);
+
+    const singleAmount = ethers.parseUnits("5", 18);
+    const batch1 = ethers.parseUnits("7", 18);
+    const batch2 = ethers.parseUnits("9", 18);
+    await token.mint(claims.target, singleAmount + batch1 + batch2);
+
+    // Single path
+    await expect(claims.connect(admin).settleClaim(user.address, singleAmount))
+      .to.emit(claims, "ClaimSettled")
+      .withArgs(user.address, singleAmount);
+
+    // Batch path - same internal _settle, no shadowing across iterations
+    const tx = claims
+      .connect(admin)
+      .settleClaimsBatch([user.address, other.address], [batch1, batch2]);
+    await expect(tx).to.emit(claims, "ClaimSettled").withArgs(user.address, batch1);
+    await expect(tx).to.emit(claims, "ClaimSettled").withArgs(other.address, batch2);
+
+    expect(await token.balanceOf(user.address)).to.equal(singleAmount + batch1);
+    expect(await token.balanceOf(other.address)).to.equal(batch2);
+  });
 });
 import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
 import { expect } from "chai";


### PR DESCRIPTION

### Summary
Renames the internal `_settle` function parameters from `beneficiary` / `amount` to `_beneficiary` / `_amount` (underscore-prefix convention) to eliminate any potential shadowing of inherited declarations flagged during audit.

### Changes
- **[contracts/TruthBountyClaims.sol](contracts/TruthBountyClaims.sol)** — Renamed `_settle` params and updated internal references. Call sites (`settleClaim`, `settleClaimsBatch`) untouched — args are positional.
- **[test/TruthBountyClaims.test.ts](test/TruthBountyClaims.test.ts)** — Added unit test asserting single and batch paths emit the correct `ClaimSettled` args and balances after the rename.

### Why
- Audit Ref **CO-190** identified parameter shadowing risk inside `_settle`.
- Underscore-prefix is the standard Solidity/OpenZeppelin convention for internal function params and disambiguates them from any state-variable or inherited-scope identifiers.
- Behavior, ABI, and storage layout are unchanged → no regressions.

### Acceptance Criteria
- [x] Implementation functional
- [x] Tests added (single + batch `ClaimSettled` args)
- [x] No regressions (ABI/storage unchanged)

### Security / Integrity
- Purely a renamimg refactor; no logic or access-control changes. No new trust assumptions.

### Risk
- Low. Internal-only rename; callers are unaffected.

### References
- Internal: Ref #CO-190
- Branch: `feat/audit-190-shadowing-settle`

closes #190  