### PR TITLE
feat(#1): implement ERC20 RewardToken with mint/burn roles and exact …

### DIFF
--- a/contracts/RewardToken.sol
+++ b/contracts/RewardToken.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/AccessControl.sol";
+
+/**
+ * @title RewardToken
+ * @notice ERC20 token with role-based minting and burning for protocol rewards
+ * @dev Uses AccessControl with MINTER_ROLE and BURNER_ROLE.
+ *      DEFAULT_ADMIN_ROLE can grant/revoke minter/burner roles.
+ */
+contract RewardToken is ERC20, AccessControl {
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+    bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
+
+    /**
+     * @param initialAdmin Address that receives DEFAULT_ADMIN_ROLE and initial supply
+     * @param initialSupply Initial token supply minted to initialAdmin
+     */
+    constructor(address initialAdmin, uint256 initialSupply) ERC20("RewardToken", "RWD") {
+        require(initialAdmin != address(0), "Invalid admin address");
+
+        _grantRole(DEFAULT_ADMIN_ROLE, initialAdmin);
+
+        if (initialSupply > 0) {
+            _mint(initialAdmin, initialSupply);
+        }
+    }
+
+    /**
+     * @notice Mint new tokens
+     * @param to Recipient address
+     * @param amount Amount to mint
+     */
+    function mint(address to, uint256 amount) external onlyRole(MINTER_ROLE) {
+        _mint(to, amount);
+    }
+
+    /**
+     * @notice Burn tokens from an address
+     * @param from Address to burn from
+     * @param amount Amount to burn
+     */
+    function burn(address from, uint256 amount) external onlyRole(BURNER_ROLE) {
+        _burn(from, amount);
+    }
+}

--- a/contracts/TruthBountyWeighted.sol
+++ b/contracts/TruthBountyWeighted.sol
@@ -130,6 +130,8 @@ contract TruthBountyWeighted is ResolverRoleTimelock, ReentrancyGuard, Pausable,
         uint256 totalWeightedFor;      // Weighted votes for claim (NEW)
         uint256 totalWeightedAgainst;  // Weighted votes against claim (NEW)
         uint256 totalStakeAmount;      // Total raw stake amount
+        uint256 totalStakedFor;        // Total raw stake for (support)
+        uint256 totalStakedAgainst;    // Total raw stake against
     }
 
     struct Vote {
@@ -295,7 +297,9 @@ contract TruthBountyWeighted is ResolverRoleTimelock, ReentrancyGuard, Pausable,
             settled: false,
             totalWeightedFor: 0,
             totalWeightedAgainst: 0,
-            totalStakeAmount: 0
+            totalStakeAmount: 0,
+            totalStakedFor: 0,
+            totalStakedAgainst: 0
         });
 
         emit ClaimCreated(claimId, msg.sender, content, verificationWindowEnd);
@@ -418,8 +422,10 @@ contract TruthBountyWeighted is ResolverRoleTimelock, ReentrancyGuard, Pausable,
         // Update claim totals with WEIGHTED stakes
         if (support) {
             claim.totalWeightedFor += effectiveStake;
+            claim.totalStakedFor += stakeAmount;
         } else {
             claim.totalWeightedAgainst += effectiveStake;
+            claim.totalStakedAgainst += stakeAmount;
         }
         claim.totalStakeAmount += stakeAmount; // Still track raw stake total
 
@@ -808,8 +814,8 @@ contract TruthBountyWeighted is ResolverRoleTimelock, ReentrancyGuard, Pausable,
         uint256 winnerWeightedStake = passed ? claim.totalWeightedFor : claim.totalWeightedAgainst;
         uint256 loserWeightedStake = passed ? claim.totalWeightedAgainst : claim.totalWeightedFor;
 
-        // Calculate total RAW stake from losers for slashing
-        uint256 loserRawStake = _calculateLoserRawStake(claimId, passed);
+        // Exact total RAW stake from losing side (pre-calculated during voting)
+        uint256 loserRawStake = passed ? claim.totalStakedAgainst : claim.totalStakedFor;
 
         // Slash the configured percentage of losing raw stake.
         slashedAmount = (loserRawStake * slashPercent) / PERCENT_DENOMINATOR;
@@ -886,28 +892,6 @@ contract TruthBountyWeighted is ResolverRoleTimelock, ReentrancyGuard, Pausable,
                 vote.slashAmount = 0;
             }
         }
-    }
-
-    /**
-     * @notice Helper to calculate total raw stake from losing side
-     * @dev Iterates through votes - in production, consider off-chain indexing
-     */
-    function _calculateLoserRawStake(
-        uint256 claimId,
-        bool passed
-    ) internal view returns (uint256 total) {
-        // Note: This is a simplified implementation
-        // In production, you'd want to track this during voting or use off-chain indexing
-        // For now, we'll use the total stake as an approximation
-        Claim storage claim = claims[claimId];
-
-        // Rough approximation: total stake * (loser weighted / total weighted)
-        uint256 totalWeighted = claim.totalWeightedFor + claim.totalWeightedAgainst;
-        uint256 loserWeighted = passed ? claim.totalWeightedAgainst : claim.totalWeightedFor;
-
-        if (totalWeighted == 0) return 0;
-
-        return (claim.totalStakeAmount * loserWeighted) / totalWeighted;
     }
 
     // ============ Admin Functions ============


### PR DESCRIPTION
closes #1 

- Add RewardToken.sol with MINTER_ROLE and BURNER_ROLE via AccessControl
- Add totalStakedFor/totalStakedAgainst to Claim struct for exact raw stake tracking
- Update _vote() to track raw stakes per side atomically
- Replace _calculateLoserRawStake() approximation with direct field access
- Remove _calculateLoserRawStake() function (no longer needed)