### PR TITLE
feat: implement weighted verification aggregation engine (SC-005)

### DIFF
--- a/contracts/TruthBountyWeighted.sol
+++ b/contracts/TruthBountyWeighted.sol
@@ -1110,6 +1110,30 @@ contract TruthBountyWeighted is ResolverRoleTimelock, ReentrancyGuard, Pausable,
         return verifierStakes[verifier];
     }
 
+    function getClaimVoterCount(uint256 claimId) external view returns (uint256) {
+        return claimVoters[claimId].length;
+    }
+
+    function getClaimVoterAt(uint256 claimId, uint256 index) external view returns (address) {
+        return claimVoters[claimId][index];
+    }
+
+    function getVerificationWeight(uint256 claimId, address verifier) external view returns (uint256) {
+        return votes[claimId][verifier].effectiveStake;
+    }
+
+    function getVerificationSupport(uint256 claimId, address verifier) external view returns (bool) {
+        return votes[claimId][verifier].support;
+    }
+
+    function getClaimVerificationWindowEnd(uint256 claimId) external view returns (uint256) {
+        return claims[claimId].verificationWindowEnd;
+    }
+
+    function getClaimSubmitter(uint256 claimId) external view returns (address) {
+        return claims[claimId].submitter;
+    }
+
     /**
      * @notice Preview the effective stake for a user
      */

--- a/contracts/VerificationAggregation.sol
+++ b/contracts/VerificationAggregation.sol
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+enum ClaimOutcome {
+    VERIFIED_TRUE,
+    VERIFIED_FALSE,
+    INCONCLUSIVE
+}
+
+struct AggregationResult {
+    ClaimOutcome outcome;
+    uint256 trueWeight;
+    uint256 falseWeight;
+    uint256 totalWeight;
+    uint256 confidence;
+}
+
+interface IVerificationSource {
+    function getClaimVoterCount(uint256 claimId) external view returns (uint256);
+    function getClaimVoterAt(uint256 claimId, uint256 index) external view returns (address);
+    function getVerificationWeight(uint256 claimId, address verifier) external view returns (uint256);
+    function getVerificationSupport(uint256 claimId, address verifier) external view returns (bool);
+    function getClaimVerificationWindowEnd(uint256 claimId) external view returns (uint256);
+    function getClaimSubmitter(uint256 claimId) external view returns (address);
+}
+
+contract VerificationAggregation {
+    uint256 public constant BASIS_POINTS_DENOMINATOR = 10000;
+    uint256 public constant MAX_VERIFICATION_COUNT = 200;
+
+    uint256 public minVerificationCount;
+    uint256 public minTotalStake;
+    uint256 public minConfidenceBps;
+
+    address public owner;
+
+    IVerificationSource public verificationSource;
+
+    mapping(uint256 => AggregationResult) private _aggregations;
+    mapping(uint256 => bool) private _aggregated;
+
+    event ClaimAggregated(uint256 indexed claimId, ClaimOutcome outcome, uint256 confidence);
+    event ThresholdsUpdated(uint256 minVerificationCount, uint256 minTotalStake, uint256 minConfidenceBps);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    error NotAggregated(uint256 claimId);
+    error AlreadyAggregated(uint256 claimId);
+    error InvalidSource();
+    error ClaimNotExists(uint256 claimId);
+    error VerificationWindowOpen(uint256 claimId);
+    error NotOwner();
+
+    modifier onlyOwner() {
+        if (msg.sender != owner) revert NotOwner();
+        _;
+    }
+
+    constructor(address _verificationSource) {
+        if (_verificationSource == address(0)) revert InvalidSource();
+        verificationSource = IVerificationSource(_verificationSource);
+        owner = msg.sender;
+        minVerificationCount = 1;
+    }
+
+    function aggregateClaim(uint256 claimId) external returns (AggregationResult memory) {
+        if (_aggregated[claimId]) revert AlreadyAggregated(claimId);
+
+        address submitter = verificationSource.getClaimSubmitter(claimId);
+        if (submitter == address(0)) revert ClaimNotExists(claimId);
+
+        uint256 verificationWindowEnd = verificationSource.getClaimVerificationWindowEnd(claimId);
+        if (block.timestamp < verificationWindowEnd) revert VerificationWindowOpen(claimId);
+
+        (uint256 trueWeight, uint256 falseWeight, uint256 totalWeight) = _calculateWeights(claimId);
+
+        uint256 voterCount = verificationSource.getClaimVoterCount(claimId);
+
+        if (voterCount < minVerificationCount || totalWeight < minTotalStake) {
+            AggregationResult memory insufficient = AggregationResult({
+                outcome: ClaimOutcome.INCONCLUSIVE,
+                trueWeight: trueWeight,
+                falseWeight: falseWeight,
+                totalWeight: totalWeight,
+                confidence: 0
+            });
+            _aggregations[claimId] = insufficient;
+            _aggregated[claimId] = true;
+            emit ClaimAggregated(claimId, ClaimOutcome.INCONCLUSIVE, 0);
+            return insufficient;
+        }
+
+        uint256 confidence = _calculateConfidence(trueWeight, falseWeight);
+        ClaimOutcome outcome = _determineOutcome(trueWeight, falseWeight, confidence);
+
+        AggregationResult memory aggregated = AggregationResult({
+            outcome: outcome,
+            trueWeight: trueWeight,
+            falseWeight: falseWeight,
+            totalWeight: totalWeight,
+            confidence: confidence
+        });
+
+        _aggregations[claimId] = aggregated;
+        _aggregated[claimId] = true;
+
+        emit ClaimAggregated(claimId, outcome, confidence);
+
+        return aggregated;
+    }
+
+    function calculateWeights(uint256 claimId) external view returns (uint256 trueWeight, uint256 falseWeight, uint256 totalWeight) {
+        return _calculateWeights(claimId);
+    }
+
+    function calculateConfidence(uint256 trueWeight, uint256 falseWeight) external pure returns (uint256) {
+        return _calculateConfidence(trueWeight, falseWeight);
+    }
+
+    function getAggregation(uint256 claimId) external view returns (AggregationResult memory) {
+        if (!_aggregated[claimId]) revert NotAggregated(claimId);
+        return _aggregations[claimId];
+    }
+
+    function isAggregated(uint256 claimId) external view returns (bool) {
+        return _aggregated[claimId];
+    }
+
+    function setThresholds(uint256 _minVerificationCount, uint256 _minTotalStake, uint256 _minConfidenceBps) external onlyOwner {
+        minVerificationCount = _minVerificationCount;
+        minTotalStake = _minTotalStake;
+        minConfidenceBps = _minConfidenceBps;
+        emit ThresholdsUpdated(_minVerificationCount, _minTotalStake, _minConfidenceBps);
+    }
+
+    function transferOwnership(address newOwner) external onlyOwner {
+        if (newOwner == address(0)) revert InvalidSource();
+        address oldOwner = owner;
+        owner = newOwner;
+        emit OwnershipTransferred(oldOwner, newOwner);
+    }
+
+    function _calculateWeights(uint256 claimId) internal view returns (uint256 trueWeight, uint256 falseWeight, uint256 totalWeight) {
+        uint256 count = verificationSource.getClaimVoterCount(claimId);
+
+        for (uint256 i = 0; i < count; i++) {
+            address voter = verificationSource.getClaimVoterAt(claimId, i);
+            bool support = verificationSource.getVerificationSupport(claimId, voter);
+            uint256 weight = verificationSource.getVerificationWeight(claimId, voter);
+
+            if (support) {
+                trueWeight += weight;
+            } else {
+                falseWeight += weight;
+            }
+        }
+
+        totalWeight = trueWeight + falseWeight;
+    }
+
+    function _calculateConfidence(uint256 trueWeight, uint256 falseWeight) internal pure returns (uint256) {
+        uint256 totalWeight = trueWeight + falseWeight;
+        if (totalWeight == 0) return 0;
+        uint256 winningWeight = trueWeight > falseWeight ? trueWeight : falseWeight;
+        return (winningWeight * BASIS_POINTS_DENOMINATOR) / totalWeight;
+    }
+
+    function _determineOutcome(uint256 trueWeight, uint256 falseWeight, uint256 confidence) internal view returns (ClaimOutcome) {
+        if (trueWeight == falseWeight && trueWeight > 0) {
+            return ClaimOutcome.INCONCLUSIVE;
+        }
+
+        if (trueWeight == 0 && falseWeight == 0) {
+            return ClaimOutcome.INCONCLUSIVE;
+        }
+
+        if (minConfidenceBps > 0 && confidence < minConfidenceBps) {
+            return ClaimOutcome.INCONCLUSIVE;
+        }
+
+        return trueWeight > falseWeight ? ClaimOutcome.VERIFIED_TRUE : ClaimOutcome.VERIFIED_FALSE;
+    }
+}

--- a/test/VerificationAggregation.t.sol
+++ b/test/VerificationAggregation.t.sol
@@ -1,0 +1,547 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import "../contracts/VerificationAggregation.sol";
+import "../contracts/TruthBountyWeighted.sol";
+import "../contracts/MockERC20.sol";
+import "../test/mocks/MockReputationOracle.sol";
+
+contract VerificationAggregationTest is Test {
+    TruthBountyWeighted public truthBounty;
+    VerificationAggregation public aggregator;
+    MockERC20 public token;
+    MockReputationOracle public oracle;
+
+    address public admin = address(0x1);
+    address public submitter = address(0x2);
+    address public verifier1 = address(0x3);
+    address public verifier2 = address(0x4);
+    address public verifier3 = address(0x5);
+    address public verifier4 = address(0x6);
+    address public verifier5 = address(0x7);
+
+    uint256 constant MIN_STAKE = 100 ether;
+    uint256 constant VERIFICATION_WINDOW = 7 days;
+    uint256 constant CONFIRMATION_DELAY = 1 hours;
+
+    function setUp() public {
+        token = new MockERC20("Test", "TST", 18);
+        oracle = new MockReputationOracle();
+
+        // Mint tokens to everyone
+        token.mint(admin, 1000000 ether);
+        token.mint(submitter, 1000000 ether);
+        token.mint(verifier1, 1000000 ether);
+        token.mint(verifier2, 1000000 ether);
+        token.mint(verifier3, 1000000 ether);
+        token.mint(verifier4, 1000000 ether);
+        token.mint(verifier5, 1000000 ether);
+
+        // Deploy TruthBountyWeighted
+        vm.prank(admin);
+        truthBounty = new TruthBountyWeighted(
+            address(token),
+            address(oracle),
+            admin,
+            admin
+        );
+
+        // Fund the bounty contract with tokens for rewards
+        vm.prank(admin);
+        token.transfer(address(truthBounty), 100000 ether);
+
+        // Deploy aggregator
+        aggregator = new VerificationAggregation(address(truthBounty));
+    }
+
+    function _approveAndStake(address verifier, uint256 amount) internal {
+        vm.prank(verifier);
+        token.approve(address(truthBounty), type(uint256).max);
+        vm.prank(verifier);
+        truthBounty.stake(amount);
+    }
+
+    function _createClaim() internal returns (uint256) {
+        vm.prank(submitter);
+        uint256 claimId = truthBounty.createClaim("QmTestHash");
+        return claimId;
+    }
+
+    function _vote(uint256 claimId, address verifier, bool support, uint256 stakeAmount) internal {
+        vm.prank(verifier);
+        truthBounty.vote(claimId, support, stakeAmount);
+    }
+
+    function _fastForwardWindow() internal {
+        vm.warp(block.timestamp + VERIFICATION_WINDOW + CONFIRMATION_DELAY + 1);
+    }
+
+    // ============ Successful Cases ============
+
+    function testUnanimousTrue() public {
+        uint256 claimId = _createClaim();
+
+        _approveAndStake(verifier1, 1000 ether);
+        _approveAndStake(verifier2, 1000 ether);
+
+        _vote(claimId, verifier1, true, 100 ether);
+        _vote(claimId, verifier2, true, 100 ether);
+
+        _fastForwardWindow();
+
+        AggregationResult memory result = aggregator.aggregateClaim(claimId);
+        assertEq(uint256(result.outcome), uint256(ClaimOutcome.VERIFIED_TRUE));
+        assertEq(result.trueWeight, 200 ether);
+        assertEq(result.falseWeight, 0);
+        assertEq(result.totalWeight, 200 ether);
+        assertEq(result.confidence, 10000);
+    }
+
+    function testUnanimousFalse() public {
+        uint256 claimId = _createClaim();
+
+        _approveAndStake(verifier1, 1000 ether);
+        _approveAndStake(verifier2, 1000 ether);
+
+        _vote(claimId, verifier1, false, 100 ether);
+        _vote(claimId, verifier2, false, 100 ether);
+
+        _fastForwardWindow();
+
+        AggregationResult memory result = aggregator.aggregateClaim(claimId);
+        assertEq(uint256(result.outcome), uint256(ClaimOutcome.VERIFIED_FALSE));
+        assertEq(result.trueWeight, 0);
+        assertEq(result.falseWeight, 200 ether);
+        assertEq(result.totalWeight, 200 ether);
+        assertEq(result.confidence, 10000);
+    }
+
+    function testMixedVerifications() public {
+        uint256 claimId = _createClaim();
+
+        _approveAndStake(verifier1, 1000 ether);
+        _approveAndStake(verifier2, 1000 ether);
+        _approveAndStake(verifier3, 1000 ether);
+
+        _vote(claimId, verifier1, true, 100 ether);
+        _vote(claimId, verifier2, true, 100 ether);
+        _vote(claimId, verifier3, false, 100 ether);
+
+        _fastForwardWindow();
+
+        AggregationResult memory result = aggregator.aggregateClaim(claimId);
+        assertEq(uint256(result.outcome), uint256(ClaimOutcome.VERIFIED_TRUE));
+        assertEq(result.trueWeight, 200 ether);
+        assertEq(result.falseWeight, 100 ether);
+        assertEq(result.totalWeight, 300 ether);
+        assertEq(result.confidence, 6666);
+    }
+
+    function testWeightedTrueMajority() public {
+        uint256 claimId = _createClaim();
+
+        _approveAndStake(verifier1, 1000 ether);
+        _approveAndStake(verifier2, 1000 ether);
+        _approveAndStake(verifier3, 1000 ether);
+
+        oracle.setReputationScore(verifier1, 2 ether);
+        oracle.setReputationScore(verifier2, 0.5 ether);
+        oracle.setReputationScore(verifier3, 0.5 ether);
+
+        _vote(claimId, verifier1, true, 100 ether);
+        _vote(claimId, verifier2, false, 100 ether);
+        _vote(claimId, verifier3, false, 100 ether);
+
+        _fastForwardWindow();
+
+        AggregationResult memory result = aggregator.aggregateClaim(claimId);
+        assertEq(uint256(result.outcome), uint256(ClaimOutcome.VERIFIED_TRUE));
+        assertEq(result.trueWeight, 200 ether);
+        assertEq(result.falseWeight, 100 ether);
+        assertEq(result.totalWeight, 300 ether);
+        assertEq(result.confidence, 6666);
+    }
+
+    function testWeightedFalseMajority() public {
+        uint256 claimId = _createClaim();
+
+        _approveAndStake(verifier1, 1000 ether);
+        _approveAndStake(verifier2, 1000 ether);
+        _approveAndStake(verifier3, 1000 ether);
+
+        oracle.setReputationScore(verifier1, 0.5 ether);
+        oracle.setReputationScore(verifier2, 2 ether);
+        oracle.setReputationScore(verifier3, 2 ether);
+
+        _vote(claimId, verifier1, true, 100 ether);
+        _vote(claimId, verifier2, false, 100 ether);
+        _vote(claimId, verifier3, false, 100 ether);
+
+        _fastForwardWindow();
+
+        AggregationResult memory result = aggregator.aggregateClaim(claimId);
+        assertEq(uint256(result.outcome), uint256(ClaimOutcome.VERIFIED_FALSE));
+        assertEq(result.trueWeight, 50 ether);
+        assertEq(result.falseWeight, 400 ether);
+        assertEq(result.totalWeight, 450 ether);
+        assertEq(result.confidence, 8888);
+    }
+
+    function testLargeVerificationSet() public {
+        uint256 claimId = _createClaim();
+
+        address[10] memory voters = [
+            address(0x10), address(0x11), address(0x12), address(0x13), address(0x14),
+            address(0x15), address(0x16), address(0x17), address(0x18), address(0x19)
+        ];
+
+        for (uint256 i = 0; i < 10; i++) {
+            token.mint(voters[i], 1000 ether);
+            _approveAndStake(voters[i], 500 ether);
+            _vote(claimId, voters[i], i < 6, 50 ether);
+        }
+
+        _fastForwardWindow();
+
+        AggregationResult memory result = aggregator.aggregateClaim(claimId);
+        assertEq(uint256(result.outcome), uint256(ClaimOutcome.VERIFIED_TRUE));
+        assertEq(result.trueWeight, 300 ether);
+        assertEq(result.falseWeight, 200 ether);
+        assertEq(result.totalWeight, 500 ether);
+        assertEq(result.confidence, 6000);
+    }
+
+    function testConfidenceCalculation() public {
+        uint256 claimId = _createClaim();
+
+        _approveAndStake(verifier1, 1000 ether);
+        _approveAndStake(verifier2, 1000 ether);
+
+        _vote(claimId, verifier1, true, 100 ether);
+        _vote(claimId, verifier2, false, 100 ether);
+
+        _fastForwardWindow();
+
+        AggregationResult memory result = aggregator.aggregateClaim(claimId);
+        assertEq(uint256(result.outcome), uint256(ClaimOutcome.INCONCLUSIVE));
+        assertEq(result.trueWeight, 100 ether);
+        assertEq(result.falseWeight, 100 ether);
+        assertEq(result.totalWeight, 200 ether);
+        assertEq(result.confidence, 5000);
+    }
+
+    // ============ Tie Cases ============
+
+    function testEqualWeightTie() public {
+        uint256 claimId = _createClaim();
+
+        _approveAndStake(verifier1, 1000 ether);
+        _approveAndStake(verifier2, 1000 ether);
+
+        _vote(claimId, verifier1, true, 100 ether);
+        _vote(claimId, verifier2, false, 100 ether);
+
+        _fastForwardWindow();
+
+        AggregationResult memory result = aggregator.aggregateClaim(claimId);
+        assertEq(uint256(result.outcome), uint256(ClaimOutcome.INCONCLUSIVE));
+        assertEq(result.trueWeight, 100 ether);
+        assertEq(result.falseWeight, 100 ether);
+        assertEq(result.confidence, 5000);
+    }
+
+    function testEqualWeightWithThresholds() public {
+        uint256 claimId = _createClaim();
+
+        _approveAndStake(verifier1, 1000 ether);
+        _approveAndStake(verifier2, 1000 ether);
+
+        _vote(claimId, verifier1, true, 100 ether);
+        _vote(claimId, verifier2, false, 100 ether);
+
+        _fastForwardWindow();
+
+        aggregator.setThresholds(1, 0, 0);
+        AggregationResult memory result = aggregator.aggregateClaim(claimId);
+        assertEq(uint256(result.outcome), uint256(ClaimOutcome.INCONCLUSIVE));
+    }
+
+    function testEqualStakeEqualConfidence() public {
+        uint256 claimId = _createClaim();
+
+        _approveAndStake(verifier1, 1000 ether);
+        _approveAndStake(verifier2, 1000 ether);
+
+        oracle.setReputationScore(verifier1, 1 ether);
+        oracle.setReputationScore(verifier2, 1 ether);
+
+        _vote(claimId, verifier1, true, 100 ether);
+        _vote(claimId, verifier2, false, 100 ether);
+
+        _fastForwardWindow();
+
+        AggregationResult memory result = aggregator.aggregateClaim(claimId);
+        assertEq(uint256(result.outcome), uint256(ClaimOutcome.INCONCLUSIVE));
+        assertEq(result.trueWeight, 100 ether);
+        assertEq(result.falseWeight, 100 ether);
+        assertEq(result.totalWeight, 200 ether);
+        assertEq(result.confidence, 5000);
+    }
+
+    function testInsufficientParticipation() public {
+        uint256 claimId = _createClaim();
+
+        _approveAndStake(verifier1, 1000 ether);
+        _vote(claimId, verifier1, true, 100 ether);
+
+        _fastForwardWindow();
+
+        aggregator.setThresholds(2, 0, 0);
+        AggregationResult memory result = aggregator.aggregateClaim(claimId);
+        assertEq(uint256(result.outcome), uint256(ClaimOutcome.INCONCLUSIVE));
+    }
+
+    function testInsufficientTotalStake() public {
+        uint256 claimId = _createClaim();
+
+        _approveAndStake(verifier1, 1000 ether);
+        _vote(claimId, verifier1, true, 100 ether);
+
+        _fastForwardWindow();
+
+        aggregator.setThresholds(1, 500 ether, 0);
+        AggregationResult memory result = aggregator.aggregateClaim(claimId);
+        assertEq(uint256(result.outcome), uint256(ClaimOutcome.INCONCLUSIVE));
+    }
+
+    function testConfidenceBelowThreshold() public {
+        uint256 claimId = _createClaim();
+
+        _approveAndStake(verifier1, 1000 ether);
+        _approveAndStake(verifier2, 1000 ether);
+        _approveAndStake(verifier3, 1000 ether);
+
+        _vote(claimId, verifier1, true, 100 ether);
+        _vote(claimId, verifier2, true, 100 ether);
+        _vote(claimId, verifier3, false, 100 ether);
+
+        _fastForwardWindow();
+
+        aggregator.setThresholds(1, 0, 7000);
+        AggregationResult memory result = aggregator.aggregateClaim(claimId);
+        assertEq(uint256(result.outcome), uint256(ClaimOutcome.INCONCLUSIVE));
+        assertEq(result.confidence, 6666);
+    }
+
+    // ============ Determinism Tests ============
+
+    function testDeterministicReaggregation() public {
+        uint256 claimId = _createClaim();
+
+        _approveAndStake(verifier1, 1000 ether);
+        _approveAndStake(verifier2, 1000 ether);
+        _approveAndStake(verifier3, 1000 ether);
+
+        _vote(claimId, verifier1, true, 100 ether);
+        _vote(claimId, verifier2, false, 100 ether);
+        _vote(claimId, verifier3, true, 100 ether);
+
+        _fastForwardWindow();
+
+        AggregationResult memory first = aggregator.aggregateClaim(claimId);
+
+        // Verify aggregation is stored
+        AggregationResult memory stored = aggregator.getAggregation(claimId);
+        assertEq(uint256(first.outcome), uint256(stored.outcome));
+        assertEq(first.trueWeight, stored.trueWeight);
+        assertEq(first.falseWeight, stored.falseWeight);
+        assertEq(first.totalWeight, stored.totalWeight);
+        assertEq(first.confidence, stored.confidence);
+    }
+
+    function testDeterministicOrderIndependence() public view {
+        uint256 trueWeight1 = 300 ether;
+        uint256 falseWeight1 = 100 ether;
+
+        uint256 trueWeight2 = 100 ether;
+        uint256 falseWeight2 = 300 ether;
+
+        // Order of weights shouldn't affect confidence calculation
+        uint256 confidence1 = aggregator.calculateConfidence(trueWeight1, falseWeight1);
+        uint256 confidence2 = aggregator.calculateConfidence(trueWeight2, falseWeight2);
+        assertEq(confidence1, confidence2);
+    }
+
+    // ============ Stress Tests ============
+
+    function testMaxParticipation() public {
+        uint256 voterCount = 50;
+        address[] memory voters = new address[](voterCount);
+
+        uint256 claimId = _createClaim();
+
+        for (uint256 i = 0; i < voterCount; i++) {
+            address voter = address(uint160(0x100 + i));
+            voters[i] = voter;
+            token.mint(voter, 1000 ether);
+            _approveAndStake(voter, 500 ether);
+            _vote(claimId, voter, i < 30, 10 ether);
+        }
+
+        _fastForwardWindow();
+
+        AggregationResult memory result = aggregator.aggregateClaim(claimId);
+
+        assertEq(uint256(result.outcome), uint256(ClaimOutcome.VERIFIED_TRUE));
+        assertEq(result.totalWeight, voterCount * 10 ether);
+        assertEq(result.trueWeight, 30 * 10 ether);
+        assertEq(result.falseWeight, 20 * 10 ether);
+        assertEq(result.confidence, 6000);
+    }
+
+    function testRepeatedAggregation() public {
+        uint256 claimId = _createClaim();
+
+        _approveAndStake(verifier1, 1000 ether);
+        _vote(claimId, verifier1, true, 100 ether);
+
+        _fastForwardWindow();
+        aggregator.aggregateClaim(claimId);
+
+        vm.expectRevert();
+        aggregator.aggregateClaim(claimId);
+    }
+
+    // ============ Gas Benchmarks ============
+
+    function testGasAggregationSingle() public {
+        uint256 claimId = _createClaim();
+        _approveAndStake(verifier1, 1000 ether);
+        _vote(claimId, verifier1, true, 100 ether);
+        _fastForwardWindow();
+
+        aggregator.aggregateClaim(claimId);
+    }
+
+    function testGasAggregationTen() public {
+        uint256 claimId = _createClaim();
+
+        for (uint256 i = 0; i < 10; i++) {
+            address voter = address(uint160(0x100 + i));
+            token.mint(voter, 1000 ether);
+            _approveAndStake(voter, 500 ether);
+            _vote(claimId, voter, i % 2 == 0, 10 ether);
+        }
+
+        _fastForwardWindow();
+        aggregator.aggregateClaim(claimId);
+    }
+
+    function testGasAggregationFifty() public {
+        uint256 claimId = _createClaim();
+
+        for (uint256 i = 0; i < 50; i++) {
+            address voter = address(uint160(0x100 + i));
+            token.mint(voter, 1000 ether);
+            _approveAndStake(voter, 500 ether);
+            _vote(claimId, voter, i % 2 == 0, 10 ether);
+        }
+
+        _fastForwardWindow();
+        aggregator.aggregateClaim(claimId);
+    }
+
+    // ============ Edge Cases ============
+
+    function testZeroVotes() public {
+        uint256 claimId = _createClaim();
+        _fastForwardWindow();
+
+        AggregationResult memory result = aggregator.aggregateClaim(claimId);
+        assertEq(uint256(result.outcome), uint256(ClaimOutcome.INCONCLUSIVE));
+        assertEq(result.trueWeight, 0);
+        assertEq(result.falseWeight, 0);
+        assertEq(result.totalWeight, 0);
+        assertEq(result.confidence, 0);
+    }
+
+    function testAlreadyAggregatedReverts() public {
+        uint256 claimId = _createClaim();
+
+        _approveAndStake(verifier1, 1000 ether);
+        _vote(claimId, verifier1, true, 100 ether);
+
+        _fastForwardWindow();
+        aggregator.aggregateClaim(claimId);
+
+        vm.expectRevert();
+        aggregator.aggregateClaim(claimId);
+    }
+
+    function testNotAggregatedReverts() public {
+        uint256 claimId = _createClaim();
+        vm.expectRevert();
+        aggregator.getAggregation(claimId);
+    }
+
+    function testIsAggregated() public {
+        uint256 claimId = _createClaim();
+
+        assertFalse(aggregator.isAggregated(claimId));
+
+        _approveAndStake(verifier1, 1000 ether);
+        _vote(claimId, verifier1, true, 100 ether);
+
+        _fastForwardWindow();
+        aggregator.aggregateClaim(claimId);
+
+        assertTrue(aggregator.isAggregated(claimId));
+    }
+
+    function testHighConfidenceThreshold() public {
+        uint256 claimId = _createClaim();
+
+        _approveAndStake(verifier1, 1000 ether);
+        _approveAndStake(verifier2, 1000 ether);
+        _approveAndStake(verifier3, 1000 ether);
+
+        oracle.setReputationScore(verifier1, 10 ether);
+        oracle.setReputationScore(verifier2, 10 ether);
+        oracle.setReputationScore(verifier3, 1 ether);
+
+        _vote(claimId, verifier1, true, 100 ether);
+        _vote(claimId, verifier2, true, 100 ether);
+        _vote(claimId, verifier3, false, 100 ether);
+
+        _fastForwardWindow();
+
+        AggregationResult memory result = aggregator.aggregateClaim(claimId);
+        assertEq(uint256(result.outcome), uint256(ClaimOutcome.VERIFIED_TRUE));
+        assertEq(result.trueWeight, 2000 ether);
+        assertEq(result.falseWeight, 100 ether);
+        assertEq(result.totalWeight, 2100 ether);
+        assertEq(result.confidence, 9523);
+    }
+
+    // ============ Event Tests ============
+
+    function testClaimAggregatedEvent() public {
+        uint256 claimId = _createClaim();
+
+        _approveAndStake(verifier1, 1000 ether);
+        _vote(claimId, verifier1, true, 100 ether);
+
+        _fastForwardWindow();
+
+        vm.expectEmit(true, true, true, true);
+        emit ClaimAggregated(claimId, ClaimOutcome.VERIFIED_TRUE, 10000);
+        aggregator.aggregateClaim(claimId);
+    }
+
+    function testThresholdsEvent() public {
+        vm.expectEmit(true, true, true, true);
+        emit ThresholdsUpdated(5, 1000 ether, 6000);
+        aggregator.setThresholds(5, 1000 ether, 6000);
+    }
+}


### PR DESCRIPTION
- Add VerificationAggregation contract with ClaimOutcome enum, AggregationResult struct
- Implement deterministic weighted consensus: TRUE/FALSE weight calculation, confidence scoring
- Add configurable thresholds: min verification count, min total stake, min confidence
- Handle ties deterministically (INCONCLUSIVE)
- Emit ClaimAggregated event for indexers
- Add IVerificationSource interface for future extensibility (reputation weighting, quadratic voting, etc.)
- Add view functions to TruthBountyWeighted for voter iteration: getClaimVoterCount, getClaimVoterAt, getVerificationWeight, getVerificationSupport, getClaimVerificationWindowEnd, getClaimSubmitter
- Write comprehensive Foundry tests: successful cases, tie handling, determinism, stress tests, gas benchmarks
- Pure integer arithmetic, no floating-point
- Order-independent aggregation guarantees identical output across all nodes

closes #289