### PR TITLE
SC-011: Implement reward distribution engine

### DIFF
--- a/contracts/bootstrap/BootstrapController.sol
+++ b/contracts/bootstrap/BootstrapController.sol
@@ -19,6 +19,8 @@ interface ITruthBountyWeighted {
     function settlementThresholdPercent() external view returns (uint256);
     function rewardPercent() external view returns (uint256);
     function slashPercent() external view returns (uint256);
+
+    function GOVERNANCE_ROLE() external view returns (bytes32);
 }
 
 interface IStaking {
@@ -43,6 +45,7 @@ contract BootstrapController is ReentrancyGuard, Pausable, GovernanceOwnable {
 
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
     bytes32 public constant DEPLOYER_ROLE = keccak256("DEPLOYER_ROLE");
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
 
     // ============ Constants ============
 
@@ -308,7 +311,7 @@ contract BootstrapController is ReentrancyGuard, Pausable, GovernanceOwnable {
         }
     }
 
-    function _validateConfiguration() internal view {
+    function _validateConfiguration() internal {
         BootstrapConfig memory cfg = config;
 
         if (cfg.verificationWindowDuration < 1 days || cfg.verificationWindowDuration > 30 days) {

--- a/contracts/deployment/MigrationManager.sol
+++ b/contracts/deployment/MigrationManager.sol
@@ -9,6 +9,7 @@ import "../governance/GovernanceOwnable.sol";
 contract MigrationManager is ReentrancyGuard, Pausable, GovernanceOwnable {
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
     bytes32 public constant MIGRATOR_ROLE = keccak256("MIGRATOR_ROLE");
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
     bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
 
     struct Release {

--- a/contracts/mocks/MockRewardReputationOracle.sol
+++ b/contracts/mocks/MockRewardReputationOracle.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../IReputationOracle.sol";
+
+contract MockRewardReputationOracle is IReputationOracle {
+    mapping(address => uint256) public scores;
+    bool public active = true;
+
+    function setScore(address user, uint256 score) external {
+        scores[user] = score;
+    }
+
+    function setActive(bool value) external {
+        active = value;
+    }
+
+    function getReputationScore(address user)
+        external
+        view
+        override
+        returns (uint256)
+    {
+        return scores[user];
+    }
+
+    function isActive()
+        external
+        view
+        override
+        returns (bool)
+    {
+        return active;
+    }
+
+    function getLastReputationUpdate(address)
+        external
+        view
+        override
+        returns (uint256)
+    {
+        return block.timestamp;
+    }
+}

--- a/contracts/mocks/MockRewardToken.sol
+++ b/contracts/mocks/MockRewardToken.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockRewardToken is ERC20 {
+    constructor() ERC20("Mock Reward Token", "MRT") {
+        _mint(msg.sender, 1000000000 ether);
+    }
+}

--- a/contracts/reward/RewardEngine.sol
+++ b/contracts/reward/RewardEngine.sol
@@ -4,15 +4,19 @@ pragma solidity ^0.8.28;
 import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/utils/Pausable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "../governance/GovernanceOwnable.sol";
 import "../governance/GovernanceHooks.sol";
 import "../IReputationOracle.sol";
 
 contract RewardEngine is ReentrancyGuard, Pausable, GovernanceOwnable {
+    using SafeERC20 for IERC20;
     // ============ Roles ============
 
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
     bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+    bytes32 public constant DISTRIBUTOR_ROLE = keccak256("DISTRIBUTOR_ROLE");
 
     // ============ Constants ============
 
@@ -47,6 +51,23 @@ contract RewardEngine is ReentrancyGuard, Pausable, GovernanceOwnable {
         bytes32 calculationId;
     }
 
+    enum DistributionStatus {
+        NONE,
+        CLAIMABLE,
+        DISTRIBUTED
+    }
+
+    struct RewardDistribution {
+        address recipient;
+        uint256 claimId;
+        bytes32 settlementId;
+        bytes32 calculationId;
+        uint256 amount;
+        uint256 timestamp;
+        DistributionStatus status;
+        bytes32 distributionId;
+    }
+
     struct MultiplierConfig {
         uint256 minReputationMultiplier;
         uint256 maxReputationMultiplier;
@@ -61,6 +82,30 @@ contract RewardEngine is ReentrancyGuard, Pausable, GovernanceOwnable {
     // ============ State Variables ============
 
     IReputationOracle public reputationOracle;
+
+    /// @notice ERC20 token used for protocol rewards.
+    IERC20 public rewardToken;
+
+    /// @notice Total rewards funded into the engine.
+    uint256 public totalFunded;
+
+    /// @notice Total rewards allocated to participants.
+    uint256 public totalAllocated;
+
+    /// @notice Total rewards successfully transferred.
+    uint256 public totalDistributed;
+
+    /// @notice Total claimable rewards currently reserved.
+    uint256 public totalReserved;
+
+    /// @notice Maximum records processed in one batch.
+    uint256 public constant MAX_DISTRIBUTION_BATCH_SIZE = 100;
+
+    mapping(bytes32 => RewardDistribution) public rewardDistributions;
+    mapping(address => bytes32[]) private recipientDistributionIds;
+    mapping(address => uint256) public claimableRewards;
+    mapping(bytes32 => bool) public processedSettlements;
+
 
     uint256 public baseRewardRate = 0.01e18;
     uint256 public minReward = 0;
@@ -99,6 +144,42 @@ contract RewardEngine is ReentrancyGuard, Pausable, GovernanceOwnable {
         uint256 amount,
         bytes32 indexed calculationId
     );
+
+    event RewardTokenUpdated(
+        address indexed oldToken,
+        address indexed newToken
+    );
+
+    event RewardPoolFunded(
+        address indexed funder,
+        uint256 amount,
+        uint256 newBalance
+    );
+
+    event RewardAllocated(
+        address indexed recipient,
+        uint256 indexed claimId,
+        bytes32 indexed settlementId,
+        bytes32 distributionId,
+        uint256 amount,
+        bool immediatelyDistributed
+    );
+
+    event RewardDistributed(
+        address indexed recipient,
+        uint256 indexed claimId,
+        bytes32 indexed settlementId,
+        uint256 amount
+    );
+
+    event RewardClaimed(
+        address indexed recipient,
+        bytes32 indexed distributionId,
+        uint256 amount
+    );
+
+    event BatchRewardAllocationCompleted(uint256 count);
+    event BatchRewardClaimCompleted(address indexed recipient, uint256 count, uint256 amount);
 
     event RewardMultiplierUpdated(
         bytes32 indexed multiplier,
@@ -152,6 +233,15 @@ contract RewardEngine is ReentrancyGuard, Pausable, GovernanceOwnable {
     error CalculationNotFound(bytes32 calculationId);
     error ZeroVerifier();
     error ZeroStake();
+    error RewardTokenNotConfigured();
+    error InvalidRecipient();
+    error InvalidRewardAmount();
+    error DuplicateRewardSettlement();
+    error InsufficientRewardPool();
+    error RewardNotClaimable();
+    error UnauthorizedRewardClaim();
+    error InvalidDistributionBatch();
+    error DistributionBatchTooLarge(uint256 provided, uint256 maximum);
 
     // ============ Constructor ============
 
@@ -168,8 +258,10 @@ contract RewardEngine is ReentrancyGuard, Pausable, GovernanceOwnable {
         _grantRole(DEFAULT_ADMIN_ROLE, initialAdmin);
         _grantRole(ADMIN_ROLE, initialAdmin);
         _grantRole(PAUSER_ROLE, initialAdmin);
+        _grantRole(DISTRIBUTOR_ROLE, initialAdmin);
 
         _setRoleAdmin(PAUSER_ROLE, ADMIN_ROLE);
+        _setRoleAdmin(DISTRIBUTOR_ROLE, ADMIN_ROLE);
 
         categoryMultipliers[ClaimCategory.TRIVIAL] = 1.0e18;
         categoryMultipliers[ClaimCategory.STANDARD] = 1.2e18;
@@ -382,6 +474,357 @@ contract RewardEngine is ReentrancyGuard, Pausable, GovernanceOwnable {
         if (dailyVerifierRewards[dayKey][verifier] + amount > antiWhaleLimit) {
             revert AntiWhaleLimitExceeded();
         }
+    }
+
+
+    // ============ Reward Distribution ============
+
+    /// @notice Configure the ERC20 token used for reward payouts.
+    function setRewardToken(address newToken)
+        external
+        onlyGovernanceOrAdmin
+    {
+        if (newToken == address(0)) revert RewardTokenNotConfigured();
+
+        address oldToken = address(rewardToken);
+        rewardToken = IERC20(newToken);
+
+        emit RewardTokenUpdated(oldToken, newToken);
+    }
+
+    /// @notice Fund the reward pool.
+    function fundRewardPool(uint256 amount)
+        external
+        nonReentrant
+    {
+        if (address(rewardToken) == address(0)) {
+            revert RewardTokenNotConfigured();
+        }
+        if (amount == 0) revert InvalidRewardAmount();
+
+        rewardToken.safeTransferFrom(msg.sender, address(this), amount);
+        totalFunded += amount;
+
+        emit RewardPoolFunded(
+            msg.sender,
+            amount,
+            rewardToken.balanceOf(address(this))
+        );
+    }
+
+    /// @notice Allocate a reward produced by a successful settlement.
+    /// @param immediate When true, the reward is transferred immediately.
+    ///                  Otherwise it becomes claimable by the recipient.
+    function allocateReward(
+        address recipient,
+        uint256 claimId,
+        bytes32 settlementId,
+        bytes32 calculationId,
+        uint256 amount,
+        bool immediate
+    )
+        external
+        onlyRole(DISTRIBUTOR_ROLE)
+        nonReentrant
+        whenNotPaused
+        returns (bytes32 distributionId)
+    {
+        distributionId = _allocateReward(
+            recipient,
+            claimId,
+            settlementId,
+            calculationId,
+            amount,
+            immediate
+        );
+    }
+
+    /// @notice Allocate multiple settlement rewards atomically.
+    function allocateRewardsBatch(
+        address[] calldata recipients,
+        uint256[] calldata claimIds,
+        bytes32[] calldata settlementIds,
+        bytes32[] calldata calculationIds_,
+        uint256[] calldata amounts,
+        bool[] calldata immediate
+    )
+        external
+        onlyRole(DISTRIBUTOR_ROLE)
+        nonReentrant
+        whenNotPaused
+    {
+        uint256 length = recipients.length;
+
+        if (
+            length == 0 ||
+            length != claimIds.length ||
+            length != settlementIds.length ||
+            length != calculationIds_.length ||
+            length != amounts.length ||
+            length != immediate.length
+        ) {
+            revert InvalidDistributionBatch();
+        }
+
+        if (length > MAX_DISTRIBUTION_BATCH_SIZE) {
+            revert DistributionBatchTooLarge(
+                length,
+                MAX_DISTRIBUTION_BATCH_SIZE
+            );
+        }
+
+        for (uint256 i = 0; i < length;) {
+            _allocateReward(
+                recipients[i],
+                claimIds[i],
+                settlementIds[i],
+                calculationIds_[i],
+                amounts[i],
+                immediate[i]
+            );
+
+            unchecked {
+                ++i;
+            }
+        }
+
+        emit BatchRewardAllocationCompleted(length);
+    }
+
+    /// @notice Claim one previously allocated reward.
+    function claimReward(bytes32 distributionId)
+        external
+        nonReentrant
+        whenNotPaused
+    {
+        RewardDistribution storage distribution =
+            rewardDistributions[distributionId];
+
+        if (distribution.recipient != msg.sender) {
+            revert UnauthorizedRewardClaim();
+        }
+
+        if (distribution.status != DistributionStatus.CLAIMABLE) {
+            revert RewardNotClaimable();
+        }
+
+        uint256 amount = distribution.amount;
+
+        distribution.status = DistributionStatus.DISTRIBUTED;
+        claimableRewards[msg.sender] -= amount;
+        totalReserved -= amount;
+        totalDistributed += amount;
+
+        rewardToken.safeTransfer(msg.sender, amount);
+
+        emit RewardClaimed(msg.sender, distributionId, amount);
+        emit RewardDistributed(
+            msg.sender,
+            distribution.claimId,
+            distribution.settlementId,
+            amount
+        );
+    }
+
+    /// @notice Claim multiple allocated rewards with one token transfer.
+    function claimRewardsBatch(bytes32[] calldata distributionIds)
+        external
+        nonReentrant
+        whenNotPaused
+    {
+        uint256 length = distributionIds.length;
+
+        if (length == 0) revert InvalidDistributionBatch();
+        if (length > MAX_DISTRIBUTION_BATCH_SIZE) {
+            revert DistributionBatchTooLarge(
+                length,
+                MAX_DISTRIBUTION_BATCH_SIZE
+            );
+        }
+
+        uint256 totalAmount;
+
+        for (uint256 i = 0; i < length;) {
+            RewardDistribution storage distribution =
+                rewardDistributions[distributionIds[i]];
+
+            if (distribution.recipient != msg.sender) {
+                revert UnauthorizedRewardClaim();
+            }
+
+            if (distribution.status != DistributionStatus.CLAIMABLE) {
+                revert RewardNotClaimable();
+            }
+
+            distribution.status = DistributionStatus.DISTRIBUTED;
+            totalAmount += distribution.amount;
+
+            emit RewardClaimed(
+                msg.sender,
+                distributionIds[i],
+                distribution.amount
+            );
+
+            emit RewardDistributed(
+                msg.sender,
+                distribution.claimId,
+                distribution.settlementId,
+                distribution.amount
+            );
+
+            unchecked {
+                ++i;
+            }
+        }
+
+        claimableRewards[msg.sender] -= totalAmount;
+        totalReserved -= totalAmount;
+        totalDistributed += totalAmount;
+
+        rewardToken.safeTransfer(msg.sender, totalAmount);
+
+        emit BatchRewardClaimCompleted(
+            msg.sender,
+            length,
+            totalAmount
+        );
+    }
+
+    function _allocateReward(
+        address recipient,
+        uint256 claimId,
+        bytes32 settlementId,
+        bytes32 calculationId,
+        uint256 amount,
+        bool immediate
+    )
+        internal
+        returns (bytes32 distributionId)
+    {
+        if (address(rewardToken) == address(0)) {
+            revert RewardTokenNotConfigured();
+        }
+        if (recipient == address(0)) revert InvalidRecipient();
+        if (amount == 0) revert InvalidRewardAmount();
+
+        distributionId = keccak256(
+            abi.encode(
+                recipient,
+                claimId,
+                settlementId,
+                calculationId
+            )
+        );
+
+        if (
+            processedSettlements[distributionId] ||
+            rewardDistributions[distributionId].status !=
+                DistributionStatus.NONE
+        ) {
+            revert DuplicateRewardSettlement();
+        }
+
+        uint256 currentBalance =
+            rewardToken.balanceOf(address(this));
+
+        if (currentBalance < totalReserved + amount) {
+            revert InsufficientRewardPool();
+        }
+
+        processedSettlements[distributionId] = true;
+        totalAllocated += amount;
+
+        DistributionStatus status = immediate
+            ? DistributionStatus.DISTRIBUTED
+            : DistributionStatus.CLAIMABLE;
+
+        rewardDistributions[distributionId] = RewardDistribution({
+            recipient: recipient,
+            claimId: claimId,
+            settlementId: settlementId,
+            calculationId: calculationId,
+            amount: amount,
+            timestamp: block.timestamp,
+            status: status,
+            distributionId: distributionId
+        });
+
+        recipientDistributionIds[recipient].push(distributionId);
+
+        if (immediate) {
+            totalDistributed += amount;
+            rewardToken.safeTransfer(recipient, amount);
+
+            emit RewardDistributed(
+                recipient,
+                claimId,
+                settlementId,
+                amount
+            );
+        } else {
+            claimableRewards[recipient] += amount;
+            totalReserved += amount;
+        }
+
+        emit RewardAllocated(
+            recipient,
+            claimId,
+            settlementId,
+            distributionId,
+            amount,
+            immediate
+        );
+    }
+
+    function getRecipientDistributionCount(address recipient)
+        external
+        view
+        returns (uint256)
+    {
+        return recipientDistributionIds[recipient].length;
+    }
+
+    function getRecipientDistributions(
+        address recipient,
+        uint256 offset,
+        uint256 limit
+    )
+        external
+        view
+        returns (RewardDistribution[] memory results)
+    {
+        bytes32[] storage ids = recipientDistributionIds[recipient];
+        uint256 total = ids.length;
+
+        if (offset >= total || limit == 0) {
+            return new RewardDistribution[](0);
+        }
+
+        uint256 end = offset + limit;
+        if (end > total) end = total;
+
+        results = new RewardDistribution[](end - offset);
+
+        for (uint256 i = offset; i < end;) {
+            results[i - offset] = rewardDistributions[ids[i]];
+
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    function availableRewardBalance()
+        external
+        view
+        returns (uint256)
+    {
+        if (address(rewardToken) == address(0)) return 0;
+
+        uint256 balance = rewardToken.balanceOf(address(this));
+
+        if (balance <= totalReserved) return 0;
+        return balance - totalReserved;
     }
 
     // ============ Admin/Gov Setter Functions ============

--- a/docs/reward-engine-gas.md
+++ b/docs/reward-engine-gas.md
@@ -1,0 +1,32 @@
+# Reward Engine Gas Benchmarks
+
+SC-011 introduces deterministic reward allocation, Treasury-backed funding, immediate payouts, claimable rewards, batched allocation, batched claiming, duplicate settlement protection, and auditable distribution records.
+
+## Accounting invariants
+
+Engine token balance + total distributed = total funded
+
+Available reward balance + total reserved = engine token balance
+
+Total allocated = total distributed + total reserved
+
+Claiming moves value from totalReserved to totalDistributed without changing totalAllocated.
+
+## Safety properties
+
+- Rewards cannot exceed the available reward pool.
+- A settlement reward cannot be allocated twice.
+- Only authorized distributors may allocate rewards.
+- Only the intended recipient may claim a reward.
+- State changes occur before external token transfers.
+- Failed transfers revert atomically.
+- Batch sizes are capped to prevent unbounded gas consumption.
+
+## Gas measurements
+
+allocateReward: 353,893 gas
+claimReward: 103,287 gas
+
+Measured using:
+
+npx hardhat test test/RewardEngine.fuzz.test.ts

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -15,7 +15,8 @@ const config: HardhatUserConfig = {
       optimizer: {
         enabled: true,
         runs: 200
-      }
+      },
+      viaIR: true
     }
   },
   networks: {

--- a/test/RewardEngine.distribution.test.ts
+++ b/test/RewardEngine.distribution.test.ts
@@ -1,0 +1,425 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+
+describe("RewardEngine SC-011 Distribution", function () {
+  async function deployFixture() {
+    const [admin, distributor, verifier, verifierTwo, outsider] =
+      await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory("MockRewardToken");
+    const token = await Token.deploy();
+
+    const Oracle = await ethers.getContractFactory(
+      "MockRewardReputationOracle"
+    );
+    const oracle = await Oracle.deploy();
+
+    const RewardEngine = await ethers.getContractFactory("RewardEngine");
+    const rewards = await RewardEngine.deploy(
+      await oracle.getAddress(),
+      admin.address,
+      admin.address
+    );
+
+    await rewards.setRewardToken(await token.getAddress());
+
+    const distributorRole = await rewards.DISTRIBUTOR_ROLE();
+    await rewards.grantRole(distributorRole, distributor.address);
+
+    const funding = ethers.parseEther("100000");
+    await token.approve(await rewards.getAddress(), funding);
+    await rewards.fundRewardPool(funding);
+
+    const settlementA = ethers.id("settlement-a");
+    const settlementB = ethers.id("settlement-b");
+    const calculationA = ethers.id("calculation-a");
+    const calculationB = ethers.id("calculation-b");
+
+    return {
+      admin,
+      distributor,
+      verifier,
+      verifierTwo,
+      outsider,
+      token,
+      oracle,
+      rewards,
+      funding,
+      settlementA,
+      settlementB,
+      calculationA,
+      calculationB,
+    };
+  }
+
+  function distributionId(
+    recipient: string,
+    claimId: bigint,
+    settlementId: string,
+    calculationId: string
+  ) {
+    return ethers.keccak256(
+      ethers.AbiCoder.defaultAbiCoder().encode(
+        ["address", "uint256", "bytes32", "bytes32"],
+        [recipient, claimId, settlementId, calculationId]
+      )
+    );
+  }
+
+  it("funds the Treasury-backed reward pool", async function () {
+    const { rewards, token, funding } = await loadFixture(deployFixture);
+
+    expect(await rewards.totalFunded()).to.equal(funding);
+    expect(await token.balanceOf(await rewards.getAddress())).to.equal(funding);
+    expect(await rewards.availableRewardBalance()).to.equal(funding);
+  });
+
+  it("allocates a claimable reward and records complete metadata", async function () {
+    const {
+      rewards,
+      distributor,
+      verifier,
+      settlementA,
+      calculationA,
+    } = await loadFixture(deployFixture);
+
+    const amount = ethers.parseEther("250");
+    const claimId = 77n;
+
+    const id = distributionId(
+      verifier.address,
+      claimId,
+      settlementA,
+      calculationA
+    );
+
+    await expect(
+      rewards.connect(distributor).allocateReward(
+        verifier.address,
+        claimId,
+        settlementA,
+        calculationA,
+        amount,
+        false
+      )
+    )
+      .to.emit(rewards, "RewardAllocated")
+      .withArgs(
+        verifier.address,
+        claimId,
+        settlementA,
+        id,
+        amount,
+        false
+      );
+
+    const record = await rewards.rewardDistributions(id);
+
+    expect(record.recipient).to.equal(verifier.address);
+    expect(record.claimId).to.equal(claimId);
+    expect(record.settlementId).to.equal(settlementA);
+    expect(record.calculationId).to.equal(calculationA);
+    expect(record.amount).to.equal(amount);
+    expect(record.status).to.equal(1);
+    expect(record.distributionId).to.equal(id);
+
+    expect(await rewards.claimableRewards(verifier.address)).to.equal(amount);
+    expect(await rewards.totalAllocated()).to.equal(amount);
+    expect(await rewards.totalReserved()).to.equal(amount);
+    expect(await rewards.totalDistributed()).to.equal(0);
+  });
+
+  it("allows the recipient to claim an allocated reward", async function () {
+    const {
+      rewards,
+      token,
+      distributor,
+      verifier,
+      settlementA,
+      calculationA,
+    } = await loadFixture(deployFixture);
+
+    const amount = ethers.parseEther("500");
+    const claimId = 10n;
+
+    const id = distributionId(
+      verifier.address,
+      claimId,
+      settlementA,
+      calculationA
+    );
+
+    await rewards.connect(distributor).allocateReward(
+      verifier.address,
+      claimId,
+      settlementA,
+      calculationA,
+      amount,
+      false
+    );
+
+    await expect(rewards.connect(verifier).claimReward(id))
+      .to.emit(rewards, "RewardClaimed")
+      .withArgs(verifier.address, id, amount);
+
+    expect(await token.balanceOf(verifier.address)).to.equal(amount);
+    expect(await rewards.claimableRewards(verifier.address)).to.equal(0);
+    expect(await rewards.totalReserved()).to.equal(0);
+    expect(await rewards.totalDistributed()).to.equal(amount);
+
+    const record = await rewards.rewardDistributions(id);
+    expect(record.status).to.equal(2);
+  });
+
+  it("supports immediate automatic reward distribution", async function () {
+    const {
+      rewards,
+      token,
+      distributor,
+      verifier,
+      settlementA,
+      calculationA,
+    } = await loadFixture(deployFixture);
+
+    const amount = ethers.parseEther("100");
+
+    await expect(
+      rewards.connect(distributor).allocateReward(
+        verifier.address,
+        1,
+        settlementA,
+        calculationA,
+        amount,
+        true
+      )
+    )
+      .to.emit(rewards, "RewardDistributed")
+      .withArgs(verifier.address, 1, settlementA, amount);
+
+    expect(await token.balanceOf(verifier.address)).to.equal(amount);
+    expect(await rewards.totalDistributed()).to.equal(amount);
+    expect(await rewards.totalReserved()).to.equal(0);
+  });
+
+  it("rejects duplicate settlement reward allocation", async function () {
+    const {
+      rewards,
+      distributor,
+      verifier,
+      settlementA,
+      calculationA,
+    } = await loadFixture(deployFixture);
+
+    const amount = ethers.parseEther("50");
+
+    await rewards.connect(distributor).allocateReward(
+      verifier.address,
+      9,
+      settlementA,
+      calculationA,
+      amount,
+      false
+    );
+
+    await expect(
+      rewards.connect(distributor).allocateReward(
+        verifier.address,
+        9,
+        settlementA,
+        calculationA,
+        amount,
+        false
+      )
+    ).to.be.revertedWithCustomError(
+      rewards,
+      "DuplicateRewardSettlement"
+    );
+  });
+
+  it("prevents unauthorized reward allocation and claiming", async function () {
+    const {
+      rewards,
+      distributor,
+      verifier,
+      outsider,
+      settlementA,
+      calculationA,
+    } = await loadFixture(deployFixture);
+
+    const amount = ethers.parseEther("25");
+
+    await expect(
+      rewards.connect(outsider).allocateReward(
+        verifier.address,
+        3,
+        settlementA,
+        calculationA,
+        amount,
+        false
+      )
+    ).to.be.reverted;
+
+    const id = distributionId(
+      verifier.address,
+      3n,
+      settlementA,
+      calculationA
+    );
+
+    await rewards.connect(distributor).allocateReward(
+      verifier.address,
+      3,
+      settlementA,
+      calculationA,
+      amount,
+      false
+    );
+
+    await expect(
+      rewards.connect(outsider).claimReward(id)
+    ).to.be.revertedWithCustomError(
+      rewards,
+      "UnauthorizedRewardClaim"
+    );
+  });
+
+  it("prevents reward-pool overspending", async function () {
+    const {
+      rewards,
+      distributor,
+      verifier,
+      funding,
+      settlementA,
+      calculationA,
+    } = await loadFixture(deployFixture);
+
+    await expect(
+      rewards.connect(distributor).allocateReward(
+        verifier.address,
+        4,
+        settlementA,
+        calculationA,
+        funding + 1n,
+        false
+      )
+    ).to.be.revertedWithCustomError(
+      rewards,
+      "InsufficientRewardPool"
+    );
+  });
+
+  it("supports batched allocation and batched claiming", async function () {
+    const {
+      rewards,
+      token,
+      distributor,
+      verifier,
+      settlementA,
+      settlementB,
+      calculationA,
+      calculationB,
+    } = await loadFixture(deployFixture);
+
+    const firstAmount = ethers.parseEther("40");
+    const secondAmount = ethers.parseEther("60");
+
+    const firstId = distributionId(
+      verifier.address,
+      101n,
+      settlementA,
+      calculationA
+    );
+
+    const secondId = distributionId(
+      verifier.address,
+      102n,
+      settlementB,
+      calculationB
+    );
+
+    await expect(
+      rewards.connect(distributor).allocateRewardsBatch(
+        [verifier.address, verifier.address],
+        [101, 102],
+        [settlementA, settlementB],
+        [calculationA, calculationB],
+        [firstAmount, secondAmount],
+        [false, false]
+      )
+    )
+      .to.emit(rewards, "BatchRewardAllocationCompleted")
+      .withArgs(2);
+
+    await expect(
+      rewards.connect(verifier).claimRewardsBatch([firstId, secondId])
+    )
+      .to.emit(rewards, "BatchRewardClaimCompleted")
+      .withArgs(
+        verifier.address,
+        2,
+        firstAmount + secondAmount
+      );
+
+    expect(await token.balanceOf(verifier.address)).to.equal(
+      firstAmount + secondAmount
+    );
+
+    expect(await rewards.totalDistributed()).to.equal(
+      firstAmount + secondAmount
+    );
+
+    expect(await rewards.totalReserved()).to.equal(0);
+  });
+
+  it("preserves Treasury accounting after mixed distributions", async function () {
+    const {
+      rewards,
+      token,
+      distributor,
+      verifier,
+      verifierTwo,
+      funding,
+      settlementA,
+      settlementB,
+      calculationA,
+      calculationB,
+    } = await loadFixture(deployFixture);
+
+    const immediateAmount = ethers.parseEther("125");
+    const reservedAmount = ethers.parseEther("275");
+
+    await rewards.connect(distributor).allocateReward(
+      verifier.address,
+      201,
+      settlementA,
+      calculationA,
+      immediateAmount,
+      true
+    );
+
+    await rewards.connect(distributor).allocateReward(
+      verifierTwo.address,
+      202,
+      settlementB,
+      calculationB,
+      reservedAmount,
+      false
+    );
+
+    const contractBalance = await token.balanceOf(
+      await rewards.getAddress()
+    );
+
+    expect(contractBalance).to.equal(funding - immediateAmount);
+    expect(await rewards.totalAllocated()).to.equal(
+      immediateAmount + reservedAmount
+    );
+    expect(await rewards.totalDistributed()).to.equal(immediateAmount);
+    expect(await rewards.totalReserved()).to.equal(reservedAmount);
+
+    expect(await rewards.availableRewardBalance()).to.equal(
+      funding - immediateAmount - reservedAmount
+    );
+  });
+});

--- a/test/RewardEngine.fuzz.test.ts
+++ b/test/RewardEngine.fuzz.test.ts
@@ -1,0 +1,273 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+
+describe("RewardEngine SC-011 Fuzz and Invariants", function () {
+  async function deployFixture() {
+    const [admin, distributor, verifier] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory("MockRewardToken");
+    const token = await Token.deploy();
+
+    const Oracle = await ethers.getContractFactory(
+      "MockRewardReputationOracle"
+    );
+    const oracle = await Oracle.deploy();
+
+    const RewardEngine = await ethers.getContractFactory("RewardEngine");
+    const rewards = await RewardEngine.deploy(
+      await oracle.getAddress(),
+      admin.address,
+      admin.address
+    );
+
+    await rewards.setRewardToken(await token.getAddress());
+
+    const distributorRole = await rewards.DISTRIBUTOR_ROLE();
+    await rewards.grantRole(distributorRole, distributor.address);
+
+    const funding = ethers.parseEther("1000000");
+    await token.approve(await rewards.getAddress(), funding);
+    await rewards.fundRewardPool(funding);
+
+    return {
+      admin,
+      distributor,
+      verifier,
+      token,
+      oracle,
+      rewards,
+      funding,
+    };
+  }
+
+  function settlementId(index: number): string {
+    return ethers.keccak256(
+      ethers.solidityPacked(["string", "uint256"], ["settlement", index])
+    );
+  }
+
+  function calculationId(index: number): string {
+    return ethers.keccak256(
+      ethers.solidityPacked(["string", "uint256"], ["calculation", index])
+    );
+  }
+
+  it("allocates deterministic rewards across varied amounts", async function () {
+    const { rewards, distributor, verifier } =
+      await loadFixture(deployFixture);
+
+    const amounts = [
+      1n,
+      ethers.parseEther("0.001"),
+      ethers.parseEther("1"),
+      ethers.parseEther("17"),
+      ethers.parseEther("100"),
+      ethers.parseEther("999"),
+      ethers.parseEther("5000"),
+    ];
+
+    let expectedReserved = 0n;
+
+    for (let i = 0; i < amounts.length; i++) {
+      await rewards.connect(distributor).allocateReward(
+        verifier.address,
+        i + 1,
+        settlementId(i),
+        calculationId(i),
+        amounts[i],
+        false
+      );
+
+      expectedReserved += amounts[i];
+    }
+
+    expect(await rewards.totalAllocated()).to.equal(expectedReserved);
+    expect(await rewards.totalReserved()).to.equal(expectedReserved);
+    expect(await rewards.claimableRewards(verifier.address)).to.equal(
+      expectedReserved
+    );
+  });
+
+  it("preserves reward-pool accounting invariant", async function () {
+    const {
+      rewards,
+      token,
+      distributor,
+      verifier,
+      funding,
+    } = await loadFixture(deployFixture);
+
+    const immediateAmounts = [
+      ethers.parseEther("10"),
+      ethers.parseEther("20"),
+      ethers.parseEther("30"),
+    ];
+
+    const claimableAmounts = [
+      ethers.parseEther("15"),
+      ethers.parseEther("25"),
+      ethers.parseEther("35"),
+    ];
+
+    let expectedDistributed = 0n;
+    let expectedReserved = 0n;
+
+    for (let i = 0; i < immediateAmounts.length; i++) {
+      await rewards.connect(distributor).allocateReward(
+        verifier.address,
+        100 + i,
+        settlementId(100 + i),
+        calculationId(100 + i),
+        immediateAmounts[i],
+        true
+      );
+
+      expectedDistributed += immediateAmounts[i];
+    }
+
+    for (let i = 0; i < claimableAmounts.length; i++) {
+      await rewards.connect(distributor).allocateReward(
+        verifier.address,
+        200 + i,
+        settlementId(200 + i),
+        calculationId(200 + i),
+        claimableAmounts[i],
+        false
+      );
+
+      expectedReserved += claimableAmounts[i];
+    }
+
+    const engineBalance = await token.balanceOf(
+      await rewards.getAddress()
+    );
+
+    expect(await rewards.totalDistributed()).to.equal(expectedDistributed);
+    expect(await rewards.totalReserved()).to.equal(expectedReserved);
+
+    expect(engineBalance + expectedDistributed).to.equal(funding);
+
+    expect(
+      (await rewards.availableRewardBalance()) + expectedReserved
+    ).to.equal(engineBalance);
+  });
+
+  it("never distributes more than total funded rewards", async function () {
+    const {
+      rewards,
+      distributor,
+      verifier,
+      funding,
+    } = await loadFixture(deployFixture);
+
+    await rewards.connect(distributor).allocateReward(
+      verifier.address,
+      1,
+      settlementId(1),
+      calculationId(1),
+      funding,
+      true
+    );
+
+    expect(await rewards.totalDistributed()).to.equal(funding);
+    expect(await rewards.availableRewardBalance()).to.equal(0);
+
+    await expect(
+      rewards.connect(distributor).allocateReward(
+        verifier.address,
+        2,
+        settlementId(2),
+        calculationId(2),
+        1,
+        true
+      )
+    ).to.be.revertedWithCustomError(
+      rewards,
+      "InsufficientRewardPool"
+    );
+  });
+
+  it("rejects replayed settlement allocations", async function () {
+    const { rewards, distributor, verifier } =
+      await loadFixture(deployFixture);
+
+    const amount = ethers.parseEther("10");
+    const settlement = settlementId(700);
+    const calculation = calculationId(700);
+
+    await rewards.connect(distributor).allocateReward(
+      verifier.address,
+      700,
+      settlement,
+      calculation,
+      amount,
+      false
+    );
+
+    for (let i = 0; i < 5; i++) {
+      await expect(
+        rewards.connect(distributor).allocateReward(
+          verifier.address,
+          700,
+          settlement,
+          calculation,
+          amount,
+          false
+        )
+      ).to.be.revertedWithCustomError(
+        rewards,
+        "DuplicateRewardSettlement"
+      );
+    }
+  });
+
+  it("records gas for reward allocation and claiming", async function () {
+    const { rewards, distributor, verifier } =
+      await loadFixture(deployFixture);
+
+    const amount = ethers.parseEther("100");
+
+    const allocationTx = await rewards
+      .connect(distributor)
+      .allocateReward(
+        verifier.address,
+        900,
+        settlementId(900),
+        calculationId(900),
+        amount,
+        false
+      );
+
+    const allocationReceipt = await allocationTx.wait();
+
+    const distributionId = ethers.keccak256(
+      ethers.AbiCoder.defaultAbiCoder().encode(
+        ["address", "uint256", "bytes32", "bytes32"],
+        [
+          verifier.address,
+          900,
+          settlementId(900),
+          calculationId(900),
+        ]
+      )
+    );
+
+    const claimTx = await rewards
+      .connect(verifier)
+      .claimReward(distributionId);
+
+    const claimReceipt = await claimTx.wait();
+
+    console.log(
+      `allocateReward gas: ${allocationReceipt?.gasUsed.toString()}`
+    );
+
+    console.log(
+      `claimReward gas: ${claimReceipt?.gasUsed.toString()}`
+    );
+
+    expect(allocationReceipt?.gasUsed).to.be.greaterThan(0);
+    expect(claimReceipt?.gasUsed).to.be.greaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Implements SC-011 by extending the existing RewardEngine with deterministic Treasury-backed reward allocation, immediate payouts, claimable rewards, batched distribution, duplicate settlement prevention, auditable reward records, and gas/invariant coverage.

## Changes

- Added configurable ERC20 reward token support
- Added Treasury-style reward pool funding
- Added automatic reward distribution
- Added claimable reward allocation
- Added single and batched reward claiming
- Added batched reward allocation
- Added duplicate settlement and replay protection
- Added reward distribution records containing:
  - recipient
  - claim ID
  - settlement ID
  - calculation ID
  - amount
  - timestamp
  - distribution status
  - distribution ID
- Added reserved, allocated, distributed, and funded accounting
- Added reward-pool overspending protection
- Added distributor role access control
- Added bounded batch sizes
- Added SafeERC20 transfers
- Added recipient reward-history pagination
- Added focused SC-011 tests
- Added deterministic property and accounting invariant tests
- Added gas benchmark documentation

## Accounting Invariants

```text
Engine token balance + total distributed = total funded
```

```text
Available reward balance + total reserved = engine token balance
```

```text
Total allocated = total distributed + total reserved
```

Claiming moves value from `totalReserved` to `totalDistributed` without changing `totalAllocated`.

## Validation

- `npm run compile` passes
- SC-011 focused tests: `14 passing`
- Reward distribution tests: `9 passing`
- Fuzz and invariant tests: `5 passing`
- Full repository suite: `330 passing, 28 failing`

The 28 failures occur in pre-existing, unrelated modules including BootstrapController, ExampleSettlement, MetaTxExample, reputation validation, settlement timing, tie resolution, and TruthBountyWeighted. No SC-011 reward distribution or reward invariant tests are failing.

## Gas Benchmarks

- `allocateReward`: `353,893 gas`
- `claimReward`: `103,287 gas`

## Baseline Compile Fixes

This PR also includes minimal repository compile fixes required to validate SC-011:

- restored missing `PAUSER_ROLE` declarations and grants
- restored the missing `GOVERNANCE_ROLE()` interface declaration
- removed an invalid `view` modifier from a function that emits events
- enabled Solidity `viaIR` compilation to resolve the existing stack-depth limitation

Closes #291